### PR TITLE
Implements #3 - Use a Consumer interface

### DIFF
--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -102,18 +102,18 @@ class TestBuilder(object):
         assert factory == converter_factory_mock
 
     def test_build(self, fake_service_cls):
-        service = builder.Builder(fake_service_cls).build()
+        service = builder.Builder(fake_service_cls()).build()
         assert isinstance(service, fake_service_cls)
 
     def test_build_failure(self, fake_service_cls):
         exception = exceptions.InvalidRequestDefinition()
         fake_service_cls.builder.build.side_effect = exception
-        uplink = builder.Builder(fake_service_cls)
+        uplink = builder.Builder(fake_service_cls())
         with pytest.raises(exceptions.UplinkBuilderError):
             uplink.build()
 
 
-def test_build(mocker, http_client_mock):
+def test_build(mocker, http_client_mock, fake_service_cls):
     builder_cls_mock = mocker.Mock()
     builder_mock = mocker.Mock(spec=builder.Builder)
     builder_cls_mock.return_value = builder_mock

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,6 +4,7 @@ import pytest
 # Local imports.
 import uplink
 from uplink import utils
+from uplink.builder import Consumer
 
 # Constants
 BASE_URL = "https://api.github.com/"
@@ -14,24 +15,20 @@ def _get_url(url):
 
 
 @uplink.headers({"Accept": "application/vnd.github.v3.full+json"})
-class GitHubService(object):
+class GitHubService(Consumer):
 
     @uplink.get("/users/{user}/repos")
     def list_repos(self, user): pass
 
 
 @pytest.fixture
-def builder(http_client_mock):
-    builder_ = uplink.Builder(GitHubService)
-    builder_.base_url = BASE_URL
-    builder_.client = http_client_mock
-    return builder_
+def github_service_and_client(http_client_mock):
+    return GitHubService(base_url=BASE_URL, http_client=http_client_mock), http_client_mock
 
-
-def test_list_repo(builder):
-    service = builder.build()
+def test_list_repo(github_service_and_client):
+    service, http_client_mock = github_service_and_client
     service.list_repos("prkumar").execute()
-    builder.client.audit_request.assert_called_with(
+    http_client_mock.audit_request.assert_called_with(
         "GET", _get_url("/users/prkumar/repos"), {
             "headers": {
                 "Accept": "application/vnd.github.v3.full+json"

--- a/uplink/client.py
+++ b/uplink/client.py
@@ -83,3 +83,4 @@ class HttpClientDecorator(BaseHttpClient):
 
     def handle_response(self, response):
         return self._connection.handle_response(response)
+


### PR DESCRIPTION
I used the Builder internally for the Consumer interface, but that can be changed quite easily.
I modified the tests to use the Consumer interface and the slightly modified Builder to fit the
new implementation - all tests pass!

I think this implementation may be a bit hard coded because Builder still exists, and as seen in the tests, you have to pass it an empty instantiated class that acts as a stub. That's a little funky - I might imagine just combining Consumer and Builder as one, and changing the tests so that they dont even touch builder, they just test Consumer immediately.