### PR TITLE
Add examples of concurrent requests to documentation

### DIFF
--- a/docs/source/advanced.rst
+++ b/docs/source/advanced.rst
@@ -17,8 +17,18 @@ parameter :py:attr:`client`:
 Making Non-Blocking Requests
 ============================
 
-Notably, the Requests library blocks while it waits for a response. For
-non-blocking IO, Uplink comes with support for asyncio and Twisted:
+Notably, the default Requests library blocks while it waits for a response. For
+non-blocking IO, Uplink comes with support for asyncio and Twisted.
+
+For short examples with each asynchronous client, checkout
+`this Gist <https://gist.github.com/prkumar/4e905edb988bc3d3d95e680ef043f934>`_.
+
+Asyncio
+-------
+
+For asyncio support, Uplink offers a `aiohttp
+<http://aiohttp.readthedocs.io/en/stable/>`_ client adapter,
+:py:class:`uplink.AiohttpClient`:
 
 .. code-block:: python
 
@@ -26,11 +36,18 @@ non-blocking IO, Uplink comes with support for asyncio and Twisted:
     # This should work with Python 3.4 and above.
     github = GitHub(base_url="...", client=uplink.AiohttpClient())
 
+Twisted
+-------
+
+To have your consumer return `Twisted Deferred
+<https://twistedmatrix.com/documents/current/core/howto/defer.html>`_
+responses, use a :py:class:`uplink.TwistedClient`:
+
+.. code-block:: python
+
     # Create a consumer that returns Twisted Deferred responses.
     # This should work with all supported Python versions.
     github = GitHub(base_url="...", client=uplink.TwistedClient())
 
-For asyncio support, we use `aiohttp
-<http://aiohttp.readthedocs.io/en/stable/>`_. The Twisted client is
-inspired by `requests-threads
+This client is inspired by `requests-threads
 <https://github.com/requests/requests-threads>`_.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -82,6 +82,11 @@ And, by default, Uplink uses the powerful `Requests
 In essence, Uplink delivers reusable and self-sufficient objects for
 accessing HTTP webservices, with minimal code and user pain ☺️ .
 
+Asynchronous Requests
+---------------------
+Uplink includes support for concurrent requests with asyncio (for Python 3.4+)
+and Twisted (for all supported Python versions). Checkout
+:ref:`non-blocking requests` for more.
 
 The User Manual
 ===============


### PR DESCRIPTION
Changes proposed in this pull request:
- Add subsection to documentation homepage that notifies reader of Uplink's support for concurrent requests 
- Under advanced usage section in documentation, add separate subsections covering each concurrent client.