### PR TITLE
Add Gitter Lobby badge to README and documentation landing page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,7 @@
 Uplink
 ******
 |PyPI Version| |Build Status| |Coverage Status| |Documentation Status|
+|Gitter|
 
 - Builds Reusable Objects for Consuming Web APIs.
 - Works with Requests, asyncio, and Twisted.
@@ -121,6 +122,9 @@ Thank you for taking the time to improve an open source project 💜
 .. |Documentation Status| image:: https://readthedocs.org/projects/uplink/badge/?version=latest
    :target: http://uplink.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
+.. |Gitter| image:: https://badges.gitter.im/python-uplink/Lobby.svg
+   :target: https://gitter.im/python-uplink/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+   :alt: Join the chat at https://gitter.im/python-uplink/Lobby
 .. |License| image:: https://img.shields.io/github/license/prkumar/uplink.svg
    :target: https://github.com/prkumar/uplink/blob/master/LICENSE
 .. |PyPI Version| image:: https://img.shields.io/github/release/prkumar/uplink/all.svg

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ Uplink 📡
 A Declarative HTTP Client for Python. Inspired by `Retrofit
 <http://square.github.io/retrofit/>`__.
 
-|Release| |Python Version| |License| |Coverage Status|
+|Release| |Python Version| |License| |Coverage Status| |Gitter|
 
 .. note::
 
@@ -116,6 +116,9 @@ Follow this guide to get up and running with Uplink.
 
 .. |Coverage Status| image:: https://coveralls.io/repos/github/prkumar/uplink/badge.svg?branch=master
    :target: https://coveralls.io/github/prkumar/uplink?branch=master
+.. |Gitter| image:: https://badges.gitter.im/python-uplink/Lobby.svg
+   :target: https://gitter.im/python-uplink/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+   :alt: Join the chat at https://gitter.im/python-uplink/Lobby
 .. |License| image:: https://img.shields.io/github/license/prkumar/uplink.svg
    :target: https://github.com/prkumar/uplink/blob/master/LICENSE
 .. |Python Version| image:: https://img.shields.io/pypi/pyversions/uplink.svg


### PR DESCRIPTION
I've created a [Gitter community page](https://gitter.im/python-uplink/Lobby#) for this repository. The chat room provides a setting for users and contributors to ask questions, tease feature ideas, find love, etc., in a more informal space than GitHub PR and issue comments. 