### PR TITLE
Add support for HTTP HEAD

### DIFF
--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -4,7 +4,8 @@ import functools
 # Local imports
 from uplink import decorators, exceptions, interfaces, types, utils
 
-__all__ = ["get", "put", "post", "patch", "delete"]
+__all__ = ["get", "head", "put", "post", "patch", "delete"]
+
 
 
 class MissingUriVariables(exceptions.InvalidRequestDefinition):
@@ -158,6 +159,7 @@ class RequestDefinition(interfaces.RequestDefinition):
 
 
 get = HttpMethodFactory("GET").__call__
+head = HttpMethodFactory("HEAD").__call__
 put = HttpMethodFactory("PUT").__call__
 post = HttpMethodFactory("POST").__call__
 patch = HttpMethodFactory("PATCH").__call__


### PR DESCRIPTION
Fixes the lack of support for HTTP Head ;)

Changes proposed in this pull request:
- Add head support, which will basically do the same thing as @get, but not return the text attr of the response, only the headers attr.

Attention: @prkumar