### PR TITLE
Build requestdefinition on access, not constructor

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,28 @@ from uplink import utils
 is_py2 = sys.version_info[0] == 2
 
 
+def test_memoization():
+    ''' Test memoization. Create a memoized function that depends on
+    another function. Call the memoized function once. Then, change the
+    underlying function and assert that the memoized function returns
+    the old memoized response '''
+
+    @utils.memoize()
+    def foo(arg):
+        # Returns whatever bar returns.
+        return bar(arg)
+
+    def bar(arg):
+        return arg
+
+    assert bar(5) == 5
+    assert foo(5) == 5
+
+    bar = lambda arg: arg * 2
+
+    assert bar(5) == 10
+    assert foo(5) == 5
+
 def test_get_arg_spec():
     if is_py2:
         code = "def func(pos1, *args, **kwargs): pass"

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -160,13 +160,13 @@ class Consumer(object):
             hook=None,
             converter_factories=()
     ):
-        self.builder = Builder()
-        self.builder.base_url = base_url
-        self.builder.add_converter_factory(*converter_factories)
+        self._builder = Builder()
+        self._builder.base_url = base_url
+        self._builder.add_converter_factory(*converter_factories)
         if client is not None:
-            self.builder.client = client
+            self._builder.client = client
         if hook is not None:
-            self.builder.hook = hook
+            self._builder.hook = hook
 
 def build(service_cls, *args, **kwargs):
     warnings.warn(

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -160,21 +160,13 @@ class Consumer(object):
             hook=None,
             converter_factories=()
     ):
-        builder = Builder()
-        builder.base_url = base_url
-        builder.add_converter_factory(*converter_factories)
+        self.builder = Builder()
+        self.builder.base_url = base_url
+        self.builder.add_converter_factory(*converter_factories)
         if client is not None:
-            builder.client = client
+            self.builder.client = client
         if hook is not None:
-            builder.hook = hook
-        self._build(builder)
-
-    def _build(self, call_builder):
-        definition_builders = helpers.get_api_definitions(self)
-        for attribute_name, definition_builder in definition_builders:
-            caller = call_builder.build(self, definition_builder)
-            setattr(self, attribute_name, caller)
-
+            self.builder.hook = hook
 
 def build(service_cls, *args, **kwargs):
     warnings.warn(

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -105,6 +105,16 @@ class RequestDefinitionBuilder(interfaces.RequestDefinitionBuilder):
         argument_handler_builder.set_request_definition_builder(self)
         method_handler_builder.set_request_definition_builder(self)
 
+    @utils.memoize()
+    def __get__(self, instance, owner):
+        ''' Get an attribute of the builder (will be called upon access)
+        :param instance: CallFactory
+        '''
+        if not instance:
+            return self
+
+        return instance.builder.build(instance, self)
+
     @property
     def method(self):
         return self._method

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -113,7 +113,7 @@ class RequestDefinitionBuilder(interfaces.RequestDefinitionBuilder):
         if not instance:
             return self
 
-        return instance.builder.build(instance, self)
+        return instance._builder.build(instance, self)
 
     @property
     def method(self):

--- a/uplink/utils.py
+++ b/uplink/utils.py
@@ -1,5 +1,6 @@
 # Standard library imports
 import collections
+from functools import wraps
 
 try:
     # Python 3.2+
@@ -57,6 +58,19 @@ try:
     import urllib.parse as urlparse
 except ImportError:
     import urlparse
+
+try:
+    from functools import lru_cache as memoize
+except ImportError:
+    def memoize():
+
+        def wrapper(func):
+            memo = {}
+            @wraps(func)
+            def wrapped(*args):
+                return memo.setdefault(args, func(*args))
+            return wrapped
+        return wrapper
 
 # Third party imports
 import uritemplate


### PR DESCRIPTION
Fixes #23

Changes proposed in this pull request:
- Change CallBuilder to not build upon init()
- RequestDefinitionBuilder builds on access
- Add memozie func

Attention: @prkumar