### PR TITLE
Add ProcessorMixin, processor_mixin.overrides Sugar

### DIFF
--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -160,21 +160,13 @@ class Consumer(object):
             hook=None,
             converter_factories=()
     ):
-        builder = Builder()
-        builder.base_url = base_url
-        builder.add_converter_factory(*converter_factories)
+        self.builder = Builder()
+        self.builder.base_url = base_url
+        self.builder.add_converter_factory(*converter_factories)
         if client is not None:
-            builder.client = client
+            self.builder.client = client
         if hook is not None:
-            builder.hook = hook
-        self._build(builder)
-
-    def _build(self, call_builder):
-        definition_builders = helpers.get_api_definitions(self)
-        for attribute_name, definition_builder in definition_builders:
-            caller = call_builder.build(self, definition_builder)
-            setattr(self, attribute_name, caller)
-
+            self.builder.hook = hook
 
 def build(service_cls, *args, **kwargs):
     warnings.warn(

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -105,6 +105,16 @@ class RequestDefinitionBuilder(interfaces.RequestDefinitionBuilder):
         argument_handler_builder.set_request_definition_builder(self)
         method_handler_builder.set_request_definition_builder(self)
 
+    @utils.memoize()
+    def __get__(self, instance, owner):
+        ''' Get an attribute of the builder (will be called upon access)
+        :param instance: CallFactory
+        '''
+        if not instance:
+            return self
+
+        return instance.builder.build(instance, self)
+
     @property
     def method(self):
         return self._method

--- a/uplink/exceptions.py
+++ b/uplink/exceptions.py
@@ -1,6 +1,8 @@
 class Error(Exception):
     """Base exception for this package"""
-    message = None
+    def __init__(self, message=None):
+        super(Error, self).__init__()
+        self.message = message
 
     def __str__(self):
         return str(self.message)

--- a/uplink/sugar/processor_mixin.py
+++ b/uplink/sugar/processor_mixin.py
@@ -1,0 +1,58 @@
+import inspect
+
+from functools import wraps
+
+from ..exceptions import Error as UplinkError
+from ..builder import CallFactory
+
+class ProcessorMixinError(UplinkError):
+    pass
+
+
+class ProcessorMixin(object):
+    ''' A mixin that can be used to extend functionality for subclasses
+    of consumers, esp. those who intend to override consumer methods '''
+
+    METHOD_OVERRIDES_ATTR = '__is_processormixin_override'
+
+    def __init__(self, *args, **kwargs):
+        super(ProcessorMixin, self).__init__(*args, **kwargs)
+        self._perform_checks()
+
+    def _perform_checks(self):
+        self._perform_overrides_checks()
+
+    def _perform_overrides_checks(self):
+        ''' Check for any functions which are decorated with @overrides to
+        see if they actually override anything '''
+        methods = inspect.getmembers(self, inspect.ismethod)
+        super_class = super(ProcessorMixin, self)
+
+        override_methods = [
+            method for method in methods if
+            hasattr(method[1], self.METHOD_OVERRIDES_ATTR) and
+            getattr(method[1], self.METHOD_OVERRIDES_ATTR) 
+        ]
+
+        for method_name, _ in override_methods:
+            if not hasattr(super_class, method_name):
+                raise ProcessorMixinError(
+                    "class {} does not have method {} to override"
+                    .format(super_class, method_name)
+                )
+
+
+            super_method = getattr(super_class, method_name)
+            if not isinstance(super_method, CallFactory):
+                raise ProcessorMixinError(
+                    "method {}::{} is not an overridable uplink request"
+                    .format(super_class, method_name)
+                )
+
+
+def overrides(func):
+    ''' A decorator to assert, upon class creation time, that all override
+    functions actually override a proper, existing function, and that they
+    are of uplink requestdefintion types '''
+    setattr(func, ProcessorMixin.METHOD_OVERRIDES_ATTR, True)
+    return func

--- a/uplink/utils.py
+++ b/uplink/utils.py
@@ -1,5 +1,6 @@
 # Standard library imports
 import collections
+from functools import wraps
 
 try:
     # Python 3.2+
@@ -57,6 +58,19 @@ try:
     import urllib.parse as urlparse
 except ImportError:
     import urlparse
+
+try:
+    from functools import lru_cache as memoize
+except ImportError:
+    def memoize():
+
+        def wrapper(func):
+            memo = {}
+            @wraps(func)
+            def wrapped(*args):
+                return memo.setdefault(args, func(*args))
+            return wrapped
+        return wrapper
 
 # Third party imports
 import uritemplate


### PR DESCRIPTION
Consider the following scenario:

An untouchable library has the following code:
```python
class APIConsumer(Consumer):
    @get("/data/{id}")
    def getdata(self, id):
        pass
```

Being the end-user, you want to implement a "Processor" on top of the consumer, so that it still [quacks like a Consumer](https://en.wikipedia.org/wiki/Duck_typing), but processes the data before returning it. You implement:
```python
class APIProcessor(APIConsumer):
    def getdata(self, id):
        data = super(APIProcessor, self).getdata(id)
        process_data(data)
        return data
```

This is all well and good, but as an end-user you might want a little more protection. For instance, what if `APIConsumer` makes the following breaking change:

```python
class APIConsumer(Consumer):
    @get("/apiv2/data/{id}")
    def getdata2(self, id):
          pass   
```

All of a sudden, your processor function no longer duck-types the way you want it to. If your processor function calls super(), this error might be averted since "super does not have attribute `getdata`". However, if it doesn't, you will never be aware of this change.

`ProcessorMixin` and `@overrides` protects you from this:
```python
class APIProcessor(ProcessorMixin, APIConsumer):
    
    @overrides
    def getdata(self, id):
        data = super(APIProcessor, self).getdata(id)
        process_data(data)
        return data

api = APIProcessor()
```

Then, you will see
```
class does not have method get_movie to override
```

This is definitely not a _necessary_ addition, and is just a _nice to have_. Hence why I've put it in a new "sugar" category.

Attention: @prkumar