### PR TITLE
Instantiate client adapter if a class is passed.

### DIFF
--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -13,9 +13,16 @@ def fake_service_cls(request_definition_builder, request_definition):
     return Service
 
 
-@pytest.fixture
-def uplink_builder():
-    return builder.Builder()
+@pytest.fixture(params=[None, 'client_class', 'client_instance'])
+def uplink_builder(request, http_client_mock):
+    b = builder.Builder()
+
+    if request.param == 'client_class':
+        b.client = http_client_mock
+    elif request.param == 'client_instance':
+        b.client = http_client_mock()
+
+    return b
 
 
 class TestResponseConverter(object):

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -39,7 +39,7 @@ class RequestPreparer(object):
     def __init__(self, uplink_builder, definition):
         self._hook = uplink_builder.hook
         self._client = uplink_builder.client
-        if issubclass(self._client, clients.interfaces.HttpClientAdapter):
+        if not isinstance(self._client, clients.interfaces.HttpClientAdapter):
             self._client = self._client()
         self._base_url = str(uplink_builder.base_url)
         self._converter_registry = self._make_converter_registry(


### PR DESCRIPTION
Fixes #26.

Simple change to allow the use case outlined in the issue, although now it will blindly try to instantiate any classes passed in, whether it implements the interface or not.

I couldn't figure out how to have pytest use a fixture within a fixture, along the lines of

```
@pytest.fixture(params=[None, http_client_mock, http_client_mock()])
```

so I went with the current workaround.

Attention: @prkumar