### PR TITLE
Fix method annotations so that they don't decorate inherited consumer methods

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -89,6 +89,21 @@ class TestMethodAnnotation(object):
                 request_definition_builder
             )
 
+    def test_call_with_child_class(self,
+                                   method_annotation,
+                                   request_definition_builder):
+        class Parent(object):
+            builder = request_definition_builder
+
+        class Child(Parent):
+            pass
+
+        # Method annotation should not decorate RequestDefinitionBuilder
+        # attribute of parent class (e.g., `Parent.builder`).
+        method_annotation(Child)
+        builder = request_definition_builder.method_handler_builder
+        assert not builder.add_annotation.called
+
 
 def test_headers(request_builder):
     headers = decorators.headers({"key_1": "value_1"})

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,3 +8,15 @@ def test_get_api_definitions(request_definition_builder):
     assert dict(helpers.get_api_definitions(Service)) == {
         "builder": request_definition_builder
     }
+
+
+def test_get_api_definitions_from_parent(request_definition_builder):
+    class Parent(object):
+        builder = request_definition_builder
+
+    class Child(Parent):
+        other_builder = request_definition_builder
+
+    assert dict(helpers.get_api_definitions(Child)) == {
+        "other_builder": request_definition_builder
+    }

--- a/uplink/helpers.py
+++ b/uplink/helpers.py
@@ -1,14 +1,31 @@
 # Standard library imports
 import collections
-import inspect
 
 # Local imports
 from uplink import interfaces, utils
 
 
 def get_api_definitions(service):
+    """
+    Returns all attributes with type
+    `uplink.interfaces.RequestDefinitionBuilder` defined on the given
+    class.
+
+    Note:
+        Only attributes defined directly on the class are considered. In
+        other words, inherited `RequestDefinitionBuilder` attributes
+        are ignored.
+
+    Args:
+        service: A class object.
+    """
     predicate = interfaces.RequestDefinitionBuilder.__instancecheck__
-    return inspect.getmembers(service, predicate)
+    try:
+        local_members = service.__dict__
+    except AttributeError:
+        return []
+    else:
+        return [(k, v) for k, v in local_members.items() if predicate(v)]
 
 
 class RequestBuilder(object):

--- a/uplink/helpers.py
+++ b/uplink/helpers.py
@@ -20,12 +20,8 @@ def get_api_definitions(service):
         service: A class object.
     """
     predicate = interfaces.RequestDefinitionBuilder.__instancecheck__
-    try:
-        local_members = service.__dict__
-    except AttributeError:
-        return []
-    else:
-        return [(k, v) for k, v in local_members.items() if predicate(v)]
+    local_members = service.__dict__
+    return [(k, v) for k, v in local_members.items() if predicate(v)]
 
 
 class RequestBuilder(object):


### PR DESCRIPTION
Fixes #27.

Changes proposed in this pull request:
- Method annotations should not annotate inherited consumer methods

Attention: @prkumar