### PR TITLE
Fix Python 2.7 coveralls.io build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
 script:
   - tox -e py
 after_success:
-  - pip install python-coveralls
+  - pip install coveralls
   - coveralls
 deploy:
   provider: pypi


### PR DESCRIPTION
The Travis CI Python 2.7 build was failing to deploy the coverage report to coveralls.io. This commit replaces the `python-coveralls` library with `coveralls-python`. The latter library reruns the coverage report and quits when `coverage.py` fails to analyze `uplink/clients/aiohttp_.py` on Python 2.7, since the file includes a `yield from` statement that requires Python 3.3+. This commit makes a one line change to the Travis CI config file to use `coveralls-python`, which by default uses the coverage report created when running the tests with `tox`.