### PR TITLE
Minor refactor of `clients` subpackage

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -192,4 +192,5 @@ intersphinx_mapping = {
     'requests': ('http://docs.python-requests.org/en/master/', None),
     'aiohttp': ('https://aiohttp.readthedocs.io/en/stable/toc.html', None),
     'marshmallow': ('https://marshmallow.readthedocs.io/en/latest/', None),
+    'twisted': ('http://twistedmatrix.com/documents/current/api/', None)
 }

--- a/examples/async-requests/asyncio_example.py
+++ b/examples/async-requests/asyncio_example.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
     # This consumer instance uses Requests to make blocking requests.
     gh_sync = GitHub(base_url=BASE_URL)
 
-    # This uses an aiohttp, an HTTP client for asyncio.
+    # This uses aiohttp, an HTTP client for asyncio.
     gh_async = GitHub(base_url=BASE_URL, client=uplink.AiohttpClient())
 
     # First, let's fetch a list of all public repositories.

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,6 +1,8 @@
+# Standard library imports
+import contextlib
+
 # Third party imports
 import pytest
-import inspect
 
 # Local imports
 from uplink.clients import interfaces, requests_, twisted_, get_client
@@ -45,14 +47,18 @@ class TestTwisted(object):
         assert request._proxy is http_client_mock.create_request()
         assert isinstance(request, twisted_.Request)
 
-    def test_create_requests_no_twisted(self, mocker, http_client_mock):
-        twisted = twisted_.TwistedClient(http_client_mock)
-
+    @staticmethod
+    @contextlib.contextmanager
+    def patch_threads(threads):
         old_threads = twisted_.threads
-        twisted_.threads = None
-        with pytest.raises(NotImplementedError):
-            twisted.create_request()
+        twisted_.threads = threads
+        yield
         twisted_.threads = old_threads
+
+    def test_create_requests_no_twisted(self, http_client_mock):
+        with self.patch_threads(None):
+            with pytest.raises(NotImplementedError):
+                twisted_.TwistedClient(http_client_mock)
 
     def test_request_send(self, mocker,  request_mock):
         deferToThread = mocker.patch.object(twisted_.threads, "deferToThread")
@@ -97,15 +103,28 @@ class TestAiohttp(object):
 
     @requires_aiohttp
     def test_request_send(self, aiohttp_session_mock):
-        aiohttp_session_mock.request.return_value = [0]
+        # Setup
+        import asyncio
+
+        @asyncio.coroutine
+        def request(*args, **kwargs):
+            return 0
+
+        aiohttp_session_mock.request = request
         client = aiohttp_.AiohttpClient(aiohttp_session_mock)
         request = aiohttp_.Request(client)
+
+        # Run
         response = request.send(1, 2, {})
-        assert inspect.isgenerator(response)
-        assert list(response) == [0]
+        loop = asyncio.get_event_loop()
+        value = loop.run_until_complete(asyncio.ensure_future(response))
+
+        # Verify
+        assert value == 0
 
     @requires_aiohttp
     def test_callback(self, aiohttp_session_mock):
+        # Setup
         import asyncio
 
         @asyncio.coroutine
@@ -115,16 +134,15 @@ class TestAiohttp(object):
         aiohttp_session_mock.request = request
         client = aiohttp_.AiohttpClient(aiohttp_session_mock, asyncio.coroutine)
         request = aiohttp_.Request(client)
+
+        # Run
         request.add_callback(lambda x: 2)
         response = request.send(1, 2, {})
-        assert inspect.isgenerator(response)
-        list(response)
-        try:
-            next(response)
-        except StopIteration as err:
-            err.value == 2
-        else:
-            assert False
+        loop = asyncio.get_event_loop()
+        value = loop.run_until_complete(asyncio.ensure_future(response))
+
+        # Verify
+        assert value == 2
 
     @requires_aiohttp
     def test_threaded_callback(self, mocker):
@@ -133,27 +151,19 @@ class TestAiohttp(object):
         def callback(response):
             return response
 
-        @asyncio.coroutine
-        def response_text():
-            pass
-
         # Mock response.
         response = mocker.Mock()
-        response.text = mocker.stub(response_text)
+        response.text = asyncio.coroutine(mocker.stub())
 
         # Run
         new_callback = aiohttp_.threaded_callback(callback)
         return_value = new_callback(response)
-        list(return_value)
+        loop = asyncio.get_event_loop()
+        value = loop.run_until_complete(asyncio.ensure_future(return_value))
 
         # Verify
         response.text.assert_called_with()
-        try:
-            next(return_value)
-        except StopIteration as err:
-            err.value == 2
-        else:
-            assert False
+        assert value == response
 
     @requires_aiohttp
     def test_threaded_coroutine(self):
@@ -193,8 +203,24 @@ class TestAiohttp(object):
         assert isinstance(threaded_coroutine, aiohttp_.ThreadedCoroutine)
         assert return_value == 1
 
+    @requires_aiohttp
+    def test_create(self, mocker):
+        # Setup
+        import asyncio
 
+        session_cls_mock = mocker.patch("aiohttp.ClientSession")
+        positionals = [1]
+        keywords = {"keyword": 2}
 
+        # Run: Create client
+        client = aiohttp_.AiohttpClient.create(*positionals, **keywords)
 
+        # Verify: session hasn't been created yet.
+        assert not session_cls_mock.called
 
+        # Run: Get session
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(asyncio.ensure_future(client.session()))
 
+        # Verify: session created with args
+        session_cls_mock.assert_called_with(*positionals, **keywords)

--- a/uplink/clients/__init__.py
+++ b/uplink/clients/__init__.py
@@ -35,12 +35,12 @@ except (SyntaxError, ImportError) as error:  # pragma: no cover
         error_message = str(error)
 
         def __init__(self, *args, **kwargs):
-            pass
-
-        def create_request(self):
             raise NotImplementedError(
                 "Failed to load `asyncio` client: %s" % self.error_message
             )
+
+        def create_request(self):
+            pass
 
 __all__ = [
     "RequestsClient",

--- a/uplink/clients/aiohttp_.py
+++ b/uplink/clients/aiohttp_.py
@@ -5,6 +5,7 @@ that sends awaitable requests.
 # Standard library imports
 import atexit
 import asyncio
+import collections
 import threading
 
 from concurrent import futures
@@ -32,25 +33,22 @@ def threaded_callback(callback):
     return new_callback
 
 
-@register.handler
-def _aiohttp_handler(client):
-    if isinstance(client, aiohttp.ClientSession):
-        return AiohttpClient(session=client)
-
-
 class AiohttpClient(interfaces.HttpClientAdapter):
     """
-    An :py:mod:`aiohttp` client adapter that creates awaitable
-    responses.
+    An :py:mod:`aiohttp` client that creates awaitable responses.
 
     Args:
         session (:py:class:`aiohttp.ClientSession`, optional):
-            A :py:mod:`aiohttp` client session that should handle
-            sending requests. If this argument is not explicitly
-            set, a new session will created automatically.
+            The session that should handle sending requests. If this
+            argument is omitted or set to :py:obj:`None`, a new session
+            will be created.
     """
 
+    __ARG_SPEC = collections.namedtuple("__ARG_SPEC", "args kwargs")
+
     def __init__(self, session=None, _sync_callback_adapter=threaded_callback):
+        if session is None:
+            session = self.__ARG_SPEC((), {})
         self._session = session
         self._sync_callback_adapter = _sync_callback_adapter
 
@@ -59,9 +57,10 @@ class AiohttpClient(interfaces.HttpClientAdapter):
 
     @asyncio.coroutine
     def session(self):
-        """Returns a `aiohttp.ClientSession` to send awaitable requests."""
-        if self._session is None:
-            self._session = aiohttp.ClientSession()
+        """Returns the underlying `aiohttp.ClientSession`."""
+        if isinstance(self._session, self.__ARG_SPEC):
+            args, kwargs = self._session
+            self._session = aiohttp.ClientSession(*args, **kwargs)
             atexit.register(self._session.close)
         return self._session
 
@@ -69,6 +68,37 @@ class AiohttpClient(interfaces.HttpClientAdapter):
         if not asyncio.iscoroutinefunction(callback):
             callback = self._sync_callback_adapter(callback)
         return callback
+
+    @staticmethod
+    @register.handler
+    def with_session(session, *args, **kwargs):
+        """
+        Builds a client instance if the first argument is a
+        :py:class:`aiohttp.ClientSession`. Otherwise, return :py:obj:`None`.
+        """
+        if isinstance(session, aiohttp.ClientSession):
+            return AiohttpClient(session, *args, **kwargs)
+
+    @classmethod
+    def create(cls, *args, **kwargs):
+        """
+        Builds a client instance with
+        :py:class:`aiohttp.ClientSession` arguments.
+
+        Instead of directly initializing this class with a
+        :py:class:`aiohttp.ClientSession`, use this method to have the
+        client lazily construct a session when sending the first
+        request. Hence, this method guarantees that the creation of the
+        underlying session happens inside of a coroutine.
+
+        Args:
+            *args: positional arguments that
+                :py:class:`aiohttp.ClientSession` takes.
+            **kwargs: keyword arguments that
+                :py:class:`aiohttp.ClientSession` takes.
+        """
+        session_build_args = cls.__ARG_SPEC(args, kwargs)
+        return AiohttpClient(session=session_build_args)
 
 
 class Request(interfaces.Request):
@@ -82,15 +112,11 @@ class Request(interfaces.Request):
         session = yield from self._client.session()
         response = yield from session.request(method, url, **extras)
         if self._callback is not None:
-            response = yield from self._execute_callback(response)
+            response = yield from self._callback(response)
         return response
 
     def add_callback(self, callback):
-        self._callback = callback
-
-    @asyncio.coroutine
-    def _execute_callback(self, response):
-        return (yield from self._client.wrap_callback(self._callback)(response))
+        self._callback = self._client.wrap_callback(callback)
 
 
 class ThreadedCoroutine(object):

--- a/uplink/clients/requests_.py
+++ b/uplink/clients/requests_.py
@@ -8,13 +8,18 @@ from uplink.clients import register, interfaces
 import requests
 
 
-@register.handler
-def _requests_handler(client):
-    if isinstance(client, requests.Session):
-        return RequestsClient(session=client)
-
-
 class RequestsClient(interfaces.HttpClientAdapter):
+    """
+    A :py:mod:`requests` client that returns
+    :py:class:`requests.Response` responses.
+
+    Args:
+        session (:py:class:`requests.Session`, optional): The session
+            that should handle sending requests. If this argument is
+            omitted or set to :py:obj:`None`, a new session will be
+            created.
+    """
+
     def __init__(self, session=None):
         if session is None:
             session = requests.Session()
@@ -23,6 +28,12 @@ class RequestsClient(interfaces.HttpClientAdapter):
 
     def create_request(self):
         return Request(self._session)
+
+    @staticmethod
+    @register.handler
+    def with_session(session, *args, **kwargs):
+        if isinstance(session, requests.Session):
+            return RequestsClient(session, *args, **kwargs)
 
 
 class Request(interfaces.Request):

--- a/uplink/clients/twisted_.py
+++ b/uplink/clients/twisted_.py
@@ -1,27 +1,31 @@
 # Third party imports
-
 try:
     from twisted.internet import threads
 except ImportError:
     threads = None
 
 # Local imports
-from uplink.clients import requests_
-from uplink.clients import interfaces
+from uplink.clients import interfaces, register
 
 
 class TwistedClient(interfaces.HttpClientAdapter):
+    """
+    Client that returns :py:class:`twisted.internet.defer.Deferred`
+    responses.
 
-    def __init__(self, client=None):
-        if client is None:
-            client = requests_.RequestsClient()
-        self._requests = client
+    Args:
+        session (:py:class:`requests.Session`, optional): The session
+            that should handle sending requests. If this argument is
+            omitted or set to :py:obj:`None`, a new session will be
+            created.
+    """
+
+    def __init__(self, session=None):
+        if threads is None:
+            raise NotImplementedError("TwistedClient is not installed.")
+        self._requests = register.get_client(session)
 
     def create_request(self):
-        if threads is None:
-            raise NotImplementedError(
-                "TwistedClient is not installed."
-            )
         return Request(self._requests.create_request())
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Update documentation for `TwistedClient` and `RequestsClient`
- Fix typo in `asyncio_example.py`
- Add `AiohttpClient.create` method, that lazily constructs an `aiohttp.ClientSession` given arguments that the class accepts on instantiation. 