### PR TITLE
Add code to execute example from github.py in async-requests folder

### DIFF
--- a/examples/async-requests/github.py
+++ b/examples/async-requests/github.py
@@ -15,18 +15,18 @@ class GitHub(uplink.Consumer):
     def get_contributors(self, owner, repo):
         """Lists contributors for the specified repository."""
 
-# Executes the code above
-# The for loop is used for readability, you can just call print(response.json())
-# Uncomment the code you wish to see in action
+if __name__ == "__main__":
+    # Executes the code above
+    # The for loop is used for readability, you can just call print(response.json())
 
-# Gets all public repositories
-# github = GitHub(BASE_URL)
-# response = github.get_repos()
-# for repos in response.json():
-#     print(repos)
-#
-# # Lists contributors for a repository
-# github = GitHub(BASE_URL)
-# response = github.get_contributors("prkumar", "uplink")
-# for contributors in response.json():
-#     print(contributors)
+    # Gets all public repositories
+    github = GitHub(BASE_URL)
+    response = github.get_repos()
+    for repos in response.json():
+        print(repos)
+
+    # Lists contributors for a repository
+    github = GitHub(BASE_URL)
+    response = github.get_contributors("prkumar", "uplink")
+    for contributors in response.json():
+        print(contributors)

--- a/examples/async-requests/github.py
+++ b/examples/async-requests/github.py
@@ -14,3 +14,19 @@ class GitHub(uplink.Consumer):
     @uplink.get("/repos/{owner}/{repo}/contributors")
     def get_contributors(self, owner, repo):
         """Lists contributors for the specified repository."""
+
+# Executes the code above
+# The for loop is used for readability, you can just call print(response.json())
+# Uncomment the code you wish to see in action
+
+# Gets all public repositories
+# github = GitHub(BASE_URL)
+# response = github.get_repos()
+# for repos in response.json():
+#     print(repos)
+#
+# # Lists contributors for a repository
+# github = GitHub(BASE_URL)
+# response = github.get_contributors("prkumar", "uplink")
+# for contributors in response.json():
+#     print(contributors)


### PR DESCRIPTION
Fixes n/a .

Changes proposed in this pull request:
I was trying to make the examples work and noticed that the file github.py didn't have a working example code, so I referred to the documentation and wrote these two bits of code to help people getting started.

I've commented them because when you run the asyncio_example.py the code in github.py will be run again.

Please let me know if you'd like me to change something 👍 

Attention: @prkumar