### PR TITLE
Allows the first argument of headers to be a str or list

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -114,9 +114,10 @@ def test_headers(request_builder):
     headers_str.modify_request(request_builder)
     assert request_builder.info["headers"] == {"key_1": "value_1"}
 
-    headers_lst = decorators.headers(["key_1", "value_1"])
+    headers_lst = decorators.headers(["key_1: value_1", "key_2: value_2"])
     headers_lst.modify_request(request_builder)
-    assert request_builder.info["headers"] == {"key_1": "value_1"}
+    header = {"key_1": "value_1", "key_2": "value_2"}
+    assert request_builder.info["headers"] == header
 
 
 def test_form_url_encoded(request_builder):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -110,6 +110,14 @@ def test_headers(request_builder):
     headers.modify_request(request_builder)
     assert request_builder.info["headers"] == {"key_1": "value_1"}
 
+    headers_str = decorators.headers("key_1: value_1")
+    headers_str.modify_request(request_builder)
+    assert request_builder.info["headers"] == {"key_1": "value_1"}
+
+    headers_lst = decorators.headers(["key_1", "value_1"])
+    headers_lst.modify_request(request_builder)
+    assert request_builder.info["headers"] == {"key_1": "value_1"}
+
 
 def test_form_url_encoded(request_builder):
     form_url_encoded = decorators.form_url_encoded()

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -104,10 +104,14 @@ class headers(MethodAnnotation):
 
     def __init__(self, arg, **kwargs):
         if isinstance(arg, str):
-            header = arg.replace(":", "").split(" ")
-            self._headers = {header[0]: header[1]}
+            key, value = map(str.strip, arg.split(":"))
+            self._headers = {key: value}
         elif isinstance(arg, list):
-            self._headers = {arg[0].replace(":", ""): arg[1]}
+            headers = {}
+            for header in arg:
+                key, value = header.split(': ')
+                headers[key] = value
+            self._headers = headers
         else:
             self._headers = dict(arg, **kwargs)
 

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -104,16 +104,15 @@ class headers(MethodAnnotation):
 
     def __init__(self, arg, **kwargs):
         if isinstance(arg, str):
-            key, value = map(str.strip, arg.split(":"))
+            key, value = self._get_header(arg)
             self._headers = {key: value}
         elif isinstance(arg, list):
-            headers = {}
-            for header in arg:
-                key, value = header.split(': ')
-                headers[key] = value
-            self._headers = headers
+            self._headers = dict(self._get_header(a) for a in arg)
         else:
             self._headers = dict(arg, **kwargs)
+
+    def _get_header(self, arg):
+        return map(str.strip, arg.split(":"))
 
     def modify_request(self, request_builder):
         """Updates header contents."""

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -103,10 +103,13 @@ class headers(MethodAnnotation):
     """
 
     def __init__(self, arg, **kwargs):
-        # TODO: allow the first argument to be a list or str, in
-        # which case you would split the strings by a colon delimiter
-        # to identify the headers.
-        self._headers = dict(arg, **kwargs)
+        if isinstance(arg, str):
+            header = arg.replace(":", "").split(" ")
+            self._headers = {header[0]: header[1]}
+        elif isinstance(arg, list):
+            self._headers = {arg[0].replace(":", ""): arg[1]}
+        else:
+            self._headers = dict(arg, **kwargs)
 
     def modify_request(self, request_builder):
         """Updates header contents."""


### PR DESCRIPTION
Changes proposed in this pull request:
With this changes a user can pass a string, list or dict to the decorator `@uplink.headers`. I've separated the str type from list type in the if statement but could try to work out another way to write this code.

**Tests:**
I've used the code in `examples/github.py` to test if everything still works without any issues. I was able to get the same results when passing a string, list or dict to the uplink.headers decorator.

The tests in `tests/tests_decorators.py` were also updated to include the different ways to write the headers decorator. To be honest there's some similar code on the test, let me know if you are okay with that or if you like me to change it.

That's all for now, I'll look forward to hear your feedback on this 👍 

Attention: @prkumar