### PR TITLE
Add decorator for defining custom response handlers

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -157,3 +157,12 @@ def test_args(request_definition_builder):
     args.modify_request_definition(request_definition_builder)
     builder = request_definition_builder.argument_handler_builder
     builder.set_annotations.assert_called_with((str, str), name=str)
+
+
+def test_response_handler(request_builder):
+    @decorators.response_handler
+    def handler(response):
+        return response
+
+    handler.modify_request(request_builder)
+    request_builder.add_transaction_hook(handler)

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -325,7 +325,7 @@ class args(MethodAnnotation):
 
 
 # noinspection PyPep8Naming
-class response_handler(MethodAnnotation):
+class response_handler(MethodAnnotation, hooks.ResponseHandler):
     """
     A decorator for creating custom response handlers.
 
@@ -362,19 +362,6 @@ class response_handler(MethodAnnotation):
             @raise_for_status
             class GitHub(Consumer):
                ...
-
-    Args:
-        func (callable): A function that defines some custom response
-            handling.
     """
-
-    def __init__(self, func):
-        self._func = func
-        self._handler = hooks.ResponseHandler(self.__handler)
-
-    def __handler(self, response):
-        new_response = self._func(response)
-        return response if new_response is None else new_response
-
     def modify_request(self, request_builder):
-        request_builder.add_transaction_hook(self._handler)
+        request_builder.add_transaction_hook(self)


### PR DESCRIPTION
Fixes #41

This PR adds the `response_handler` decorator, that enables users to define custom response handling. 

## Overview

To register a function as a custom response handler, decorate the function with this class. The decorated function should accept a single positional argument, an HTTP response object:
```python
@response_handler
def raise_for_status(response):
    response.raise_for_status()
    return response
```

Then, to apply custom response handling to a request method, simply decorate the method with the registered response handler:
```python
@raise_for_status
@get("/user/posts")
def get_posts(self):
    """Fetch all posts for the current users."""
```

To apply custom response handling on all request methods of a `uplink.Consumer` subclass, simply decorate the class with the registered response handler:
```python
@raise_for_status
class GitHub(Consumer):
    ...
```

## TODO
- [ ] Add documentation: functions decorated with `response_handler` can be passed into the `hook` parameter of `Consumer` constructor.