### PR TITLE
Add decorator for defining custom error handling

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -166,3 +166,12 @@ def test_response_handler(request_builder):
 
     handler.modify_request(request_builder)
     request_builder.add_transaction_hook(handler)
+
+
+def test_error_handler(request_builder):
+    @decorators.error_handler
+    def handler(*_):
+        return True
+
+    handler.modify_request(request_builder)
+    request_builder.add_transaction_hook(handler)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,8 +1,6 @@
 # Local imports
 from uplink import hooks
 
-# TODO: Add test for `uplink.TransactionHookChain`
-
 
 class TestTransactionHook(object):
     def test_handle_response(self):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -27,6 +27,14 @@ class TestRequestAuditor(object):
         auditor.assert_called_with(1, 2, 3)
 
 
+class TestExceptionHandler(object):
+    def test_handle_exception(self, mocker):
+        handler = mocker.stub()
+        eh = hooks.ExceptionHandler(handler)
+        eh.handle_exception(1, 2, 3)
+        handler.assert_called_with(1, 2, 3)
+
+
 class TestTransactionHookChain(object):
 
     def test_delegate_audit_request(self, transaction_hook_mock):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -46,3 +46,10 @@ class TestTransactionHookChain(object):
         chain = hooks.TransactionHookChain(transaction_hook_mock)
         chain.handle_response({})
         transaction_hook_mock.handle_response.assert_called_with({})
+
+    def test_delegate_handle_exception(self, transaction_hook_mock):
+        chain = hooks.TransactionHookChain(transaction_hook_mock)
+        chain.handle_exception(None, None, None)
+        transaction_hook_mock.handle_exception.assert_called_with(
+            None, None, None
+        )

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -62,6 +62,7 @@ class RequestPreparer(object):
         hook.audit_request(request_builder.method, url, request_builder.info)
         sender = self._client.create_request()
         sender.add_callback(hook.handle_response)
+        sender.add_error_handler(hook.handle_exception)
         return sender.send(request_builder.method, url, request_builder.info)
 
     def create_request_builder(self, definition):

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -46,7 +46,7 @@ class RequestPreparer(object):
         hook.audit_request(request_builder.method, url, request_builder.info)
         sender = self._client.create_request()
         sender.add_callback(hook.handle_response)
-        sender.add_error_handler(hook.handle_exception)
+        sender.add_exception_handler(hook.handle_exception)
         return sender.send(request_builder.method, url, request_builder.info)
 
     def create_request_builder(self, definition):

--- a/uplink/clients/aiohttp_.py
+++ b/uplink/clients/aiohttp_.py
@@ -137,8 +137,8 @@ class Request(interfaces.Request):
     def add_callback(self, callback):
         self._callback = self._client.wrap_callback(callback)
 
-    def add_error_handler(self, error_handler):
-        self._error_handler.set_handler(error_handler)
+    def add_exception_handler(self, exception_handler):
+        self._error_handler.set_handler(exception_handler)
 
 
 class ThreadedCoroutine(object):

--- a/uplink/clients/helpers.py
+++ b/uplink/clients/helpers.py
@@ -1,0 +1,18 @@
+class ExceptionHandler(object):
+
+    def __init__(self, exception_class=Exception):
+        self._exc_cls = exception_class
+        self._handler = None
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.handle(exc_type, exc_val, exc_tb)
+
+    def set_handler(self, handler):
+        self._handler = handler
+
+    def handle(self, exc_type, exc_val, exc_tb):
+        if self._handler is not None and isinstance(exc_val, self._exc_cls):
+            self._handler(exc_type, exc_val, exc_tb)

--- a/uplink/clients/helpers.py
+++ b/uplink/clients/helpers.py
@@ -16,3 +16,16 @@ class ExceptionHandler(object):
     def handle(self, exc_type, exc_val, exc_tb):
         if self._handler is not None and isinstance(exc_val, self._exc_cls):
             self._handler(exc_type, exc_val, exc_tb)
+
+
+class ExceptionHandlerMixin(object):
+    __exception_handler = None
+
+    @property
+    def _exception_handler(self):
+        if self.__exception_handler is None:
+            self.__exception_handler = ExceptionHandler()
+        return self.__exception_handler
+
+    def add_exception_handler(self, exception_handler):
+        self._exception_handler.set_handler(exception_handler)

--- a/uplink/clients/interfaces.py
+++ b/uplink/clients/interfaces.py
@@ -14,6 +14,5 @@ class Request(object):
     def add_callback(self, callback):
         raise NotImplementedError
 
-    # TODO: Consider renaming this to `add_exception_handler`
-    def add_error_handler(self, error_handler):
+    def add_exception_handler(self, exception_handler):
         raise NotImplementedError

--- a/uplink/clients/interfaces.py
+++ b/uplink/clients/interfaces.py
@@ -13,3 +13,7 @@ class Request(object):
 
     def add_callback(self, callback):
         raise NotImplementedError
+
+    # TODO: Consider renaming this to `add_exception_handler`
+    def add_error_handler(self, error_handler):
+        raise NotImplementedError

--- a/uplink/clients/requests_.py
+++ b/uplink/clients/requests_.py
@@ -63,5 +63,5 @@ class Request(interfaces.Request):
     def add_callback(self, callback):
         self._callback = callback
 
-    def add_error_handler(self, error_handler):
-        self._error_handler.set_handler(error_handler)
+    def add_exception_handler(self, exception_handler):
+        self._error_handler.set_handler(exception_handler)

--- a/uplink/clients/requests_.py
+++ b/uplink/clients/requests_.py
@@ -2,7 +2,7 @@
 import atexit
 
 # Local imports
-from uplink.clients import register, interfaces
+from uplink.clients import helpers, interfaces, register
 
 # Third party imports
 import requests
@@ -48,16 +48,21 @@ class Request(interfaces.Request):
     def __init__(self, session):
         self._session = session
         self._callback = None
+        self._error_handler = helpers.ExceptionHandler()
 
     def send(self, method, url, extras):
-        response = self._session.request(
-            method=method,
-            url=url,
-            **extras
-        )
+        with self._error_handler:
+            response = self._session.request(
+                method=method,
+                url=url,
+                **extras
+            )
         if self._callback is not None:
             response = self._callback(response)
         return response
 
     def add_callback(self, callback):
         self._callback = callback
+
+    def add_error_handler(self, error_handler):
+        self._error_handler.set_handler(error_handler)

--- a/uplink/clients/requests_.py
+++ b/uplink/clients/requests_.py
@@ -42,15 +42,14 @@ class RequestsClient(interfaces.HttpClientAdapter):
         return session
 
 
-class Request(interfaces.Request):
+class Request(helpers.ExceptionHandlerMixin, interfaces.Request):
 
     def __init__(self, session):
         self._session = session
         self._callback = None
-        self._error_handler = helpers.ExceptionHandler()
 
     def send(self, method, url, extras):
-        with self._error_handler:
+        with self._exception_handler:
             response = self._session.request(
                 method=method,
                 url=url,
@@ -62,6 +61,3 @@ class Request(interfaces.Request):
 
     def add_callback(self, callback):
         self._callback = callback
-
-    def add_exception_handler(self, exception_handler):
-        self._error_handler.set_handler(exception_handler)

--- a/uplink/clients/twisted_.py
+++ b/uplink/clients/twisted_.py
@@ -40,12 +40,11 @@ class TwistedClient(interfaces.HttpClientAdapter):
         return Request(self._requests.create_request())
 
 
-class Request(interfaces.Request):
+class Request(helpers.ExceptionHandlerMixin, interfaces.Request):
 
     def __init__(self, proxy):
         self._proxy = proxy
         self._callback = None
-        self._error_handler = helpers.ExceptionHandler()
 
     def send(self, method, url, extras):
         deferred = threads.deferToThread(
@@ -62,10 +61,7 @@ class Request(interfaces.Request):
     def add_callback(self, callback):
         self._callback = callback
 
-    def add_exception_handler(self, exception_handler):
-        self._error_handler.set_handler(exception_handler)
-
     def handle_failure(self, failure):
         tb = failure.getTracebackObject()
-        self._error_handler.handle(failure.type, failure.value, tb)
+        self._exception_handler.handle(failure.type, failure.value, tb)
         failure.raiseException()

--- a/uplink/clients/twisted_.py
+++ b/uplink/clients/twisted_.py
@@ -56,7 +56,7 @@ class Request(interfaces.Request):
         )
         if self._callback is not None:
             deferred.addCallback(self._callback)
-        deferred.addErrback(self._handle_failure)
+        deferred.addErrback(self.handle_failure)
         return deferred
 
     def add_callback(self, callback):
@@ -65,7 +65,7 @@ class Request(interfaces.Request):
     def add_exception_handler(self, exception_handler):
         self._error_handler.set_handler(exception_handler)
 
-    def _handle_failure(self, failure):
+    def handle_failure(self, failure):
         tb = failure.getTracebackObject()
         self._error_handler.handle(failure.type, failure.value, tb)
         failure.raiseException()

--- a/uplink/clients/twisted_.py
+++ b/uplink/clients/twisted_.py
@@ -62,8 +62,8 @@ class Request(interfaces.Request):
     def add_callback(self, callback):
         self._callback = callback
 
-    def add_error_handler(self, error_handler):
-        self._error_handler.set_handler(error_handler)
+    def add_exception_handler(self, exception_handler):
+        self._error_handler.set_handler(exception_handler)
 
     def _handle_failure(self, failure):
         tb = failure.getTracebackObject()

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -325,7 +325,7 @@ class args(MethodAnnotation):
 
 
 # noinspection PyPep8Naming
-class error_handler(MethodAnnotation):
+class error_handler(MethodAnnotation, hooks.ExceptionHandler):
     """
     A decorator for creating custom error handlers.
 
@@ -337,7 +337,7 @@ class error_handler(MethodAnnotation):
     Example:
         .. code-block:: python
 
-            @error_handle
+            @error_handler
             def raise_api_error(exc_type, exc_val, exc_tb):
                 # wrap client error with custom API error
                 ...
@@ -363,14 +363,6 @@ class error_handler(MethodAnnotation):
             @raise_api_error
             class GitHub(Consumer):
                ...
-
-    Args:
-        func (callable): A function that defines some custom error
-            handling.
     """
-
-    def __init__(self, func):
-        self._handler = hooks.ExceptionHandler(func)
-
     def modify_request(self, request_builder):
-        request_builder.add_transaction_hook(self._handler)
+        request_builder.add_transaction_hook(self)

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -408,6 +408,11 @@ class error_handler(MethodAnnotation, hooks.ExceptionHandler):
             @raise_api_error
             class GitHub(Consumer):
                ...
+
+    Note:
+        Error handlers can not completely suppress exceptions. The
+        original exception is thrown if the error handler doesn't throw
+        anything.
     """
     def modify_request(self, request_builder):
         request_builder.add_transaction_hook(self)

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -321,3 +321,5 @@ class args(MethodAnnotation):
         request_definition_builder.argument_handler_builder.set_annotations(
             self._annotations, **self._more_annotations
         )
+
+# TODO: Add exception handler decorator

--- a/uplink/hooks.py
+++ b/uplink/hooks.py
@@ -113,16 +113,3 @@ class ExceptionHandler(TransactionHook):
 
     def handle_exception(self, *args, **kwargs):
         return self._handle(*args, **kwargs)
-
-
-class ExceptionHandler(TransactionHook):
-    """
-    Transaction hook that handles an exception thrown while waiting for
-    a response, using the provided function.
-    """
-
-    def __init__(self, exception_handler):
-        self._handle = exception_handler
-
-    def handle_exception(self, *args, **kwargs):
-        return self._handle(*args, **kwargs)

--- a/uplink/hooks.py
+++ b/uplink/hooks.py
@@ -37,7 +37,7 @@ class TransactionHook(object):
         """
         return response
 
-    def handle_exception(self, exc_type, exc_val, exc_tb):
+    def handle_exception(self, exc_type, exc_val, exc_tb):  # pragma: no cover
         """
         Handles an exception thrown while waiting for a response from
         the server.

--- a/uplink/hooks.py
+++ b/uplink/hooks.py
@@ -37,6 +37,18 @@ class TransactionHook(object):
         """
         return response
 
+    def handle_exception(self, exc_type, exc_val, exc_tb):
+        """
+        Handles an exception thrown while waiting for a response from
+        the server.
+
+        Args:
+            exc_type: The type of the exception.
+            exc_val: The exception instance raised.
+            exc_tb: A traceback instance.
+        """
+        pass
+
 
 class TransactionHookChain(TransactionHook):
     """
@@ -59,6 +71,10 @@ class TransactionHookChain(TransactionHook):
             response = hook.handle_response(response, *args, **kwargs)
         return response
 
+    def handle_exception(self, *args, **kwargs):
+        for hook in self._hooks:
+            hook.handle_exception(*args, **kwargs)
+
 
 class RequestAuditor(TransactionHook):
     """
@@ -79,8 +95,34 @@ class ResponseHandler(TransactionHook):
     time of instantiation.
     """
 
-    def __init__(self, handler):
-        self._handle = handler
+    def __init__(self, response_handler):
+        self._handle = response_handler
 
     def handle_response(self, *args, **kwargs):
+        return self._handle(*args, **kwargs)
+
+
+class ExceptionHandler(TransactionHook):
+    """
+    Transaction hook that handles an exception thrown while waiting for
+    a response, using the provided function.
+    """
+
+    def __init__(self, exception_handler):
+        self._handle = exception_handler
+
+    def handle_exception(self, *args, **kwargs):
+        return self._handle(*args, **kwargs)
+
+
+class ExceptionHandler(TransactionHook):
+    """
+    Transaction hook that handles an exception thrown while waiting for
+    a response, using the provided function.
+    """
+
+    def __init__(self, exception_handler):
+        self._handle = exception_handler
+
+    def handle_exception(self, *args, **kwargs):
         return self._handle(*args, **kwargs)


### PR DESCRIPTION
## Overview

A decorator for creating custom error handlers.

To register a function as a custom error handler, decorate the function with this class. The decorated function should accept three positional arguments: (1) the type of the exception, (2) the exception instance raised, and (3) a traceback instance.
```python
@error_handler
def raise_api_error(exc_type, exc_val, exc_tb):
    # wrap client error with custom API error
    ...
```

Then, to apply custom error handling to a request method, simply decorate the method with the registered error handler:
```python
@raise_api_error
@get("/user/posts")
def get_posts(self):
    """Fetch all posts for the current users."""
```

To apply custom error handling on all request methods of a `uplink.Consumer` subclass, simply decorate the class with the registered error handler:
```python
@raise_api_error
class GitHub(Consumer):
    ...
```

### TODO
- [ ] Add documentation: function decorated with `error_handler` can be used with the `hook` parameter of the `Consumer` constructor.