### PR TITLE
Set request properties from constructor arguments

### DIFF
--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -91,7 +91,8 @@ def test_build(
         mocker,
         http_client_mock,
         converter_factory_mock,
-        fake_service_cls
+        fake_service_cls,
+        transaction_hook_mock
 ):
     # Monkey-patch the Builder class.
     builder_cls_mock = mocker.Mock()
@@ -104,7 +105,8 @@ def test_build(
         base_url="example.com",
         client=http_client_mock,
         converter=converter_factory_mock,
-        auth=("username", "password")
+        auth=("username", "password"),
+        hook=transaction_hook_mock
     )
     assert builder_mock.base_url == "example.com"
     assert builder_mock.client is http_client_mock

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -47,11 +47,7 @@ class TestRequestPreparer(object):
         uplink_builder.base_url = "https://example.com"
         request_preparer = builder.RequestPreparer(uplink_builder)
         request_preparer.prepare_request(request_builder)
-        transaction_hook_mock.audit_request.assert_called_with(
-            "METHOD",
-            "https://example.com/example/path",
-            {}
-        )
+        transaction_hook_mock.audit_request.assert_called_with(request_builder)
 
 
 class TestCallFactory(object):

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -64,6 +64,27 @@ class TestRequests(object):
         )
         assert session.cred == ("username", "password")
 
+    def test_create_request(self):
+        client = requests_.RequestsClient()
+        request = client.create_request()
+        assert isinstance(request, requests_.Request)
+
+    def test_request_send(self, mocker):
+        # Setup
+        import requests
+        session_mock = mocker.Mock(spec=requests.Session)
+        session_mock.request.return_value = "response"
+        callback = mocker.stub()
+        client = requests_.Request(session_mock)
+        client.add_callback(callback)
+
+        # Run
+        client.send("method", "url", {})
+
+        # Verify
+        session_mock.request.assert_called_with(method="method", url="url")
+        callback.assert_called_with(session_mock.request.return_value)
+
 
 class TestTwisted(object):
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -24,14 +24,6 @@ class TestCast(object):
         assert return_value == 3
 
 
-class TestResponseBodyConverter(object):
-    def test_convert(self):
-        converter_ = converters.ResponseBodyConverter()
-        response = "json response"
-        converted = converter_.convert(response)
-        assert converted == response
-
-
 class TestRequestBodyConverter(object):
     def test_convert_str(self):
         converter_ = converters.RequestBodyConverter()

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -106,6 +106,8 @@ class TestMethodAnnotation(object):
         builder = request_definition_builder.method_handler_builder
         assert not builder.add_annotation.called
 
+# TODO: Refactor function test cases into test case class.
+
 
 def test_headers(request_builder):
     headers = decorators.headers({"key_1": "value_1"})
@@ -176,6 +178,13 @@ def test_args_decorate_function(mocker):
     func = mocker.stub()
     args(func)
     handler.set_annotations.assert_called_with((str, str), name=str)
+
+
+def test_args_call_old(request_definition_builder):
+    annotation = decorators.args(str, str, name=str)
+    annotation(request_definition_builder)
+    handler = request_definition_builder.method_handler_builder
+    handler.add_annotation.assert_called_with(annotation)
 
 
 def test_response_handler(request_builder):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -106,7 +106,7 @@ class TestMethodAnnotation(object):
         builder = request_definition_builder.method_handler_builder
         assert not builder.add_annotation.called
 
-# TODO: Refactor function test cases into test case class.
+# TODO: Refactor test cases for method annotations into test case class.
 
 
 def test_headers(request_builder):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,17 +21,17 @@ class GitHubService(uplink.Consumer):
 
 
 @pytest.fixture
-def github_service_and_client(transaction_hook_mock):
+def github_service_and_client(http_client_mock):
     return (
-        GitHubService(base_url=BASE_URL, hook=transaction_hook_mock),
-        transaction_hook_mock
+        GitHubService(base_url=BASE_URL, client=http_client_mock),
+        http_client_mock
     )
 
 
 def test_list_repo(github_service_and_client):
-    service, transaction_hook_mock = github_service_and_client
+    service, http_client = github_service_and_client
     service.list_repos("prkumar")
-    transaction_hook_mock.audit_request.assert_called_with(
+    http_client.create_request().send.assert_called_with(
         "GET", _get_url("/users/prkumar/repos"), {
             "headers": {
                 "Accept": "application/vnd.github.v3.full+json"

--- a/uplink/auth.py
+++ b/uplink/auth.py
@@ -6,16 +6,15 @@ import collections
 # Third-party imports
 from requests import auth
 
+# Local imports
+from uplink import utils
+
 __all__ = []
-
-
-def _no_auth(*_):
-    pass
 
 
 def get_auth(auth_object=None):
     if auth_object is None:
-        return _no_auth
+        return utils.no_op
     elif isinstance(auth_object, collections.Iterable):
         return BasicAuth(*auth_object)
     elif callable(auth_object):

--- a/uplink/converters/__init__.py
+++ b/uplink/converters/__init__.py
@@ -21,11 +21,6 @@ class Cast(interfaces.Converter):
         return self._converter.convert(value)
 
 
-class ResponseBodyConverter(interfaces.Converter):
-    def convert(self, response):
-        return response
-
-
 class RequestBodyConverter(interfaces.Converter):
     def convert(self, value):
         if isinstance(value, str):
@@ -49,7 +44,7 @@ class StandardConverter(interfaces.ConverterFactory):
     """
 
     def make_response_body_converter(self, type_, *args, **kwargs):
-        return ResponseBodyConverter()  # pragma: no cover
+        return None  # pragma: no cover
 
     def make_request_body_converter(self, type_, *args, **kwargs):
         return Cast(type_, RequestBodyConverter())  # pragma: no cover

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -317,13 +317,13 @@ class args(MethodAnnotation):
         self._annotations = annotations
         self._more_annotations = more_annotations
 
-    def __call__(self, func):
-        if inspect.isfunction(func):
-            handler = types.ArgumentAnnotationHandlerBuilder.from_func(func)
+    def __call__(self, obj):
+        if inspect.isfunction(obj):
+            handler = types.ArgumentAnnotationHandlerBuilder.from_func(obj)
             self._helper(handler)
-            return func
+            return obj
         else:
-            return super(args, self).__call__(func)
+            return super(args, self).__call__(obj)
 
     def _helper(self, builder):
         builder.set_annotations(self._annotations, **self._more_annotations)

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -2,7 +2,7 @@
 import inspect
 
 # Local imports
-from uplink import exceptions, helpers, hooks, interfaces
+from uplink import exceptions, helpers, hooks, interfaces, types
 
 
 __all__ = [
@@ -32,16 +32,15 @@ class HttpMethodNotSupport(exceptions.AnnotationError):
         )
 
 
-class MethodAnnotationHandlerBuilder(
-    interfaces.AnnotationHandlerBuilder
-):
+class MethodAnnotationHandlerBuilder(interfaces.AnnotationHandlerBuilder):
 
     def __init__(self):
         self._method_annotations = list()
 
     def add_annotation(self, annotation, *args_, **kwargs):
-        super(MethodAnnotationHandlerBuilder, self).add_annotation(annotation)
         self._method_annotations.append(annotation)
+        super(MethodAnnotationHandlerBuilder, self).add_annotation(annotation)
+        return annotation
 
     def build(self):
         return MethodAnnotationHandler(self._method_annotations)
@@ -318,11 +317,20 @@ class args(MethodAnnotation):
         self._annotations = annotations
         self._more_annotations = more_annotations
 
+    def __call__(self, func):
+        if inspect.isfunction(func):
+            handler = types.ArgumentAnnotationHandlerBuilder.from_func(func)
+            self._helper(handler)
+            return func
+        else:
+            return super(args, self).__call__(func)
+
+    def _helper(self, builder):
+        builder.set_annotations(self._annotations, **self._more_annotations)
+
     def modify_request_definition(self, request_definition_builder):
         """Modifies dynamic requests with given annotations"""
-        request_definition_builder.argument_handler_builder.set_annotations(
-            self._annotations, **self._more_annotations
-        )
+        self._helper(request_definition_builder.argument_handler_builder)
 
 
 # noinspection PyPep8Naming

--- a/uplink/hooks.py
+++ b/uplink/hooks.py
@@ -83,10 +83,7 @@ class RequestAuditor(TransactionHook):
     """
 
     def __init__(self, auditor):
-        self._audit = auditor
-
-    def audit_request(self, *args, **kwargs):
-        return self._audit(*args, **kwargs)
+        self.audit_request = auditor
 
 
 class ResponseHandler(TransactionHook):
@@ -95,11 +92,8 @@ class ResponseHandler(TransactionHook):
     time of instantiation.
     """
 
-    def __init__(self, response_handler):
-        self._handle = response_handler
-
-    def handle_response(self, *args, **kwargs):
-        return self._handle(*args, **kwargs)
+    def __init__(self, handler):
+        self.handle_response = handler
 
 
 class ExceptionHandler(TransactionHook):
@@ -109,7 +103,4 @@ class ExceptionHandler(TransactionHook):
     """
 
     def __init__(self, exception_handler):
-        self._handle = exception_handler
-
-    def handle_exception(self, *args, **kwargs):
-        return self._handle(*args, **kwargs)
+        self.handle_exception = exception_handler

--- a/uplink/hooks.py
+++ b/uplink/hooks.py
@@ -16,16 +16,8 @@ class TransactionHook(object):
     points of an HTTP transaction.
     """
 
-    def audit_request(self, method, url, extras):  # pragma: no cover
-        """
-        Inspects details of a request before it is sent.
-
-        Args:
-            method (str): The HTTP request method (e.g., "GET").
-            url (str): The URL that identifies the target resource.
-            extras (dict): A mapping of other request metadata
-                (e.g., headers).
-        """
+    def audit_request(self, request_builder):  # pragma: no cover
+        """Inspects details of a request before it is sent."""
         pass
 
     def handle_response(self, response):

--- a/uplink/interfaces.py
+++ b/uplink/interfaces.py
@@ -31,22 +31,19 @@ Annotation = AnnotationMeta(
 
 
 class AnnotationHandlerBuilder(object):
-    __request_definition_builder = None
-
-    def set_annotations(self, *annotations, **kwargs):
-        for annotation in annotations:
-            self.add_annotation(annotation)
-
-    def add_annotation(self, annotation, *args, **kwargs):
-        annotation.modify_request_definition(self.request_definition_builder)
-
-    def set_request_definition_builder(self, request_definition_builder):
-        if self.__request_definition_builder is None:
-            self.__request_definition_builder = request_definition_builder
+    __listener = None
 
     @property
-    def request_definition_builder(self):
-        return self.__request_definition_builder
+    def listener(self):
+        return self.__listener
+
+    @listener.setter
+    def listener(self, listener):
+        self.__listener = listener
+
+    def add_annotation(self, annotation, *args, **kwargs):
+        if self.__listener is not None:
+            self.__listener(annotation)
 
     def is_done(self):
         return True
@@ -145,4 +142,3 @@ class Auth(object):
 
     def __call__(self, request_builder):
         raise NotImplementedError
-

--- a/uplink/types.py
+++ b/uplink/types.py
@@ -42,25 +42,29 @@ class ArgumentNotFound(exceptions.AnnotationError):
         self.message = self.message % (name, func.__name__)
 
 
-class MissingArgumentAnnotations(exceptions.InvalidRequestDefinition):
-    message = "Missing annotation for argument(s): '%s'."
-    implicit_message = " (Implicit path variables: '%s')"
+class ArgumentAnnotationHandlerBuilder(interfaces.AnnotationHandlerBuilder):
+    __ANNOTATION_BUILDER_KEY = "#ANNOTATION_BUILDER_KEY#"
 
-    def __init__(self, missing, path_variables):
-        missing, path_variables = list(missing), list(path_variables)
-        self.message = self.message % "', '".join(missing)
-        if path_variables:
-            self.message += self.implicit_message % "', '".join(path_variables)
+    @classmethod
+    def from_func(cls, func):
+        if not hasattr(func, cls.__ANNOTATION_BUILDER_KEY):
+            spec = utils.get_arg_spec(func)
+            handler = cls(func, spec.args)
+            setattr(func, cls.__ANNOTATION_BUILDER_KEY, handler)
+            handler.add_annotations_from_spec(spec)
+        return getattr(func, cls.__ANNOTATION_BUILDER_KEY)
 
-
-class ArgumentAnnotationHandlerBuilder(
-    interfaces.AnnotationHandlerBuilder
-):
     def __init__(self, func, arguments, func_is_method=True):
         self._arguments = arguments[func_is_method:]
         self._argument_types = collections.OrderedDict.fromkeys(self._arguments)
         self._defined = 0
         self._func = func
+
+    def add_annotations_from_spec(self, spec):
+        if spec.args:
+            # Ignore `self` instance reference
+            spec.annotations.pop(spec.args[0], None)
+        self.set_annotations(spec.annotations)
 
     @property
     def missing_arguments(self):
@@ -101,24 +105,15 @@ class ArgumentAnnotationHandlerBuilder(
     def is_done(self):
         return self.remaining_args_count == 0
 
-    def _auto_fill_remaining_arguments(self):
-        uri_vars = set(self.request_definition_builder.uri.remaining_variables)
-        missing = list(self.missing_arguments)
-        still_missing = set(missing) - uri_vars
-
-        # Preserve order of function parameters.
-        matching = [p for p in missing if p in uri_vars]
-
-        if still_missing:
-            raise MissingArgumentAnnotations(still_missing, matching)
-        self.set_annotations(dict.fromkeys(matching, Path))
+    @property
+    def _types(self):
+        types = self._argument_types
+        return ((k, types[k]) for k in types if types[k] is not None)
 
     def build(self):
-        if not self.is_done():
-            self._auto_fill_remaining_arguments()
         return ArgumentAnnotationHandler(
             self._func,
-            self._argument_types,
+            collections.OrderedDict(self._types)
         )
 
 
@@ -138,6 +133,9 @@ class ArgumentAnnotationHandler(interfaces.AnnotationHandler):
     def handle_call(self, request_builder, args, kwargs):
         call_args = utils.get_call_args(self._func, None, *args, **kwargs)
         for name in self.get_relevant_arguments(call_args):
+            if call_args[name] is self._arguments[name].OPTIONAL:
+                # Optional argument is not set, so skip handling it.
+                continue
             self.handle_argument(
                 request_builder,
                 self._arguments[name],
@@ -155,14 +153,16 @@ class ArgumentAnnotationHandler(interfaces.AnnotationHandler):
 
 
 class ArgumentAnnotation(interfaces.Annotation):
+    # TODO: Add documentation for this constant
+    OPTIONAL = None
+
     can_be_static = True
 
     def __call__(self, request_definition_builder):
         request_definition_builder.argument_handler_builder.add_annotation(self)
         return request_definition_builder
 
-    def modify_request_definition(self, request_definition_builder):
-        # pragma: no cover
+    def modify_request_definition(self, definition_builder):  # pragma: no cover
         pass
 
     def modify_request(self, request_builder, value):  # pragma: no cover
@@ -220,6 +220,26 @@ class NamedArgument(TypedArgument):
         raise NotImplementedError
 
 
+class FuncDecoratorMixin(object):
+    @classmethod
+    def is_static_call(cls, *args_, **kwargs):
+        if super(FuncDecoratorMixin, cls).is_static_call(*args_, **kwargs):
+            return True
+        try:
+            is_func = inspect.isfunction(args_[0])
+        except IndexError:
+            return False
+        else:
+            return is_func and not (kwargs or args_[1:])
+
+    def __call__(self, obj):
+        if inspect.isfunction(obj):
+            ArgumentAnnotationHandlerBuilder.from_func(obj).add_annotation(self)
+            return obj
+        else:
+            return super(FuncDecoratorMixin, self).__call__(obj)
+
+
 class Path(NamedArgument):
     """
     Substitution of a path variable in a `URI template
@@ -267,7 +287,7 @@ class Path(NamedArgument):
         request_builder.uri.set_variable({self.name: value})
 
 
-class Query(NamedArgument):
+class Query(FuncDecoratorMixin, NamedArgument):
     """
     Set a dynamic query parameter.
 
@@ -343,7 +363,7 @@ class Query(NamedArgument):
         )
 
 
-class QueryMap(TypedArgument):
+class QueryMap(FuncDecoratorMixin, TypedArgument):
     """
     A mapping of query arguments.
 
@@ -380,7 +400,7 @@ class QueryMap(TypedArgument):
         Query.update_params(request_builder.info, value, self._encoded)
 
 
-class Header(NamedArgument):
+class Header(FuncDecoratorMixin, NamedArgument):
     """
     Pass a header as a method argument at runtime.
 
@@ -406,7 +426,7 @@ class Header(NamedArgument):
         request_builder.info["headers"][self.name] = value
 
 
-class HeaderMap(TypedArgument):
+class HeaderMap(FuncDecoratorMixin, TypedArgument):
     """Pass a mapping of header fields at runtime."""
 
     @property
@@ -594,7 +614,7 @@ class Url(ArgumentAnnotation):
                 \"""Execute a GET requests against the given endpoint\"""
     """
 
-    class DynamicUrlAssignmentFailed(exceptions.AnnotationError):
+    class DynamicUrlAssignmentFailed(exceptions.InvalidRequestDefinition):
         """Raised when the attempt to set dynamic url fails."""
         message = "Failed to set dynamic url annotation on `%s`. "
 

--- a/uplink/types.py
+++ b/uplink/types.py
@@ -133,9 +133,6 @@ class ArgumentAnnotationHandler(interfaces.AnnotationHandler):
     def handle_call(self, request_builder, args, kwargs):
         call_args = utils.get_call_args(self._func, None, *args, **kwargs)
         for name in self.get_relevant_arguments(call_args):
-            if call_args[name] is self._arguments[name].OPTIONAL:
-                # Optional argument is not set, so skip handling it.
-                continue
             self.handle_argument(
                 request_builder,
                 self._arguments[name],
@@ -153,9 +150,6 @@ class ArgumentAnnotationHandler(interfaces.AnnotationHandler):
 
 
 class ArgumentAnnotation(interfaces.Annotation):
-    # TODO: Add documentation for this constant
-    OPTIONAL = None
-
     can_be_static = True
 
     def __call__(self, request_definition_builder):

--- a/uplink/utils.py
+++ b/uplink/utils.py
@@ -84,6 +84,10 @@ Signature = collections.namedtuple(
 Request = collections.namedtuple("Request", "method uri info return_type")
 
 
+def no_op(*_):
+    pass
+
+
 class URIBuilder(object):
 
     @staticmethod


### PR DESCRIPTION
Fixes #64.

These commits enable users to use argument annotations with the constructor of a Consumer subclass. These annotations define all invocations of any request method defined on the subclass. For instance:

```python
class GitHub(uplink.Consumer):
    def __init__(self, access_token: uplink.Query("access-token")):
       ...
```