### PR TITLE
Add `Consumer._inject` method and `inject` decorator

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,5 +69,7 @@ def uplink_builder_mock(mocker):
 def request_builder(mocker):
     builder = mocker.MagicMock(spec=helpers.RequestBuilder)
     builder.info = collections.defaultdict(dict)
+    builder.get_converter.return_value = converter_mock
+    converter_mock.convert = lambda x: x
     return builder
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -168,3 +168,21 @@ def test_setting_request_method(request_definition_builder):
     assert callable(consumer.request_method)
 
 
+def test_inject(
+        mocker,
+        fake_service_cls,
+        transaction_hook_mock
+):
+    # Monkey-patch the Builder class.
+    builder_cls_mock = mocker.Mock()
+    builder_mock = mocker.Mock(wraps=builder.Builder())
+    builder_cls_mock.return_value = builder_mock
+    mocker.patch.object(builder, "Builder", builder_cls_mock)
+
+    service = builder.build(fake_service_cls)
+
+    # Verify
+    service._inject(transaction_hook_mock)
+    builder_mock.add_hook.assert_called_with(transaction_hook_mock)
+
+

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -55,7 +55,7 @@ class TestMethodAnnotationHandler(object):
 
 class TestMethodAnnotation(object):
     class FakeMethodAnnotation(decorators.MethodAnnotation):
-        can_be_static = True
+        _can_be_static = True
 
     def test_call_with_class(self,
                              method_annotation,

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -220,7 +220,7 @@ def test_response_handler(request_builder):
         return response
 
     handler.modify_request(request_builder)
-    request_builder.add_transaction_hook(handler)
+    request_builder.add_transaction_hook.assert_called_with(handler)
 
 
 def test_error_handler(request_builder):
@@ -229,4 +229,10 @@ def test_error_handler(request_builder):
         return True
 
     handler.modify_request(request_builder)
-    request_builder.add_transaction_hook(handler)
+    request_builder.add_transaction_hook.assert_called_with(handler)
+
+
+def test_inject(request_builder, transaction_hook_mock):
+    handler = decorators.inject(transaction_hook_mock)
+    handler.modify_request(request_builder)
+    request_builder.add_transaction_hook.assert_called_with(handler)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,3 +1,6 @@
+# Third party imports
+import pytest
+
 # Local imports
 from uplink import hooks
 
@@ -44,6 +47,12 @@ class TestTransactionHookChain(object):
         chain = hooks.TransactionHookChain(transaction_hook_mock)
         chain.handle_response({})
         transaction_hook_mock.handle_response.assert_called_with({})
+
+    def test_delegate_handle_response_multiple(self, transaction_hook_mock):
+        chain = hooks.TransactionHookChain(
+            transaction_hook_mock, transaction_hook_mock)
+        chain.handle_response({})
+        transaction_hook_mock.call_count == 2
 
     def test_delegate_handle_exception(self, transaction_hook_mock):
         chain = hooks.TransactionHookChain(transaction_hook_mock)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,7 +1,7 @@
 import pytest
 
 # Local imports
-from uplink import types
+from uplink import hooks, types
 from uplink.converters import keys
 
 
@@ -38,7 +38,7 @@ class ArgumentTestCase(object):
         assert self.type_cls().converter_key == self.expected_converter_key
 
     def test_is_static(self):
-        assert self.type_cls.can_be_static == self.expected_can_be_static
+        assert self.type_cls._can_be_static == self.expected_can_be_static
 
     def test_static_call(self, mocker, request_definition_builder):
         request_definition_builder = self.type_cls(request_definition_builder)
@@ -52,6 +52,11 @@ class FuncDecoratorTestCase(object):
         def func(a1, a2): return a1, a2
         output = self.type_cls(func)
         assert output is func
+
+    def test_equals(self):
+        assert isinstance(
+            self.type_cls().equals("hello"),
+            hooks.TransactionHook)
 
 
 class TestArgumentAnnotationHandlerBuilder(object):
@@ -140,11 +145,11 @@ class TestArgumentAnnotationHandlerBuilder(object):
 
 class TestArgumentAnnotationHandler(object):
 
-    @inject_args
-    def test_get_relevant_arguments(self, args):
+    def test_get_relevant_arguments(self):
+        args = {"arg1": "value1"}
         annotation_handler = types.ArgumentAnnotationHandler(None, args)
-        relevant = annotation_handler.get_relevant_arguments(args[1:])
-        assert list(relevant) == args[1:]
+        relevant = annotation_handler.get_relevant_arguments(args)
+        assert list(relevant) == list(args.items())
 
     def test_handle_call(self, request_builder, converter_mock, mocker):
         def dummy(arg1): return arg1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,28 +7,6 @@ from uplink import utils
 is_py2 = sys.version_info[0] == 2
 
 
-def test_memoization():
-    ''' Test memoization. Create a memoized function that depends on
-    another function. Call the memoized function once. Then, change the
-    underlying function and assert that the memoized function returns
-    the old memoized response '''
-
-    @utils.memoize()
-    def foo(arg):
-        # Returns whatever bar returns.
-        return bar(arg)
-
-    def bar(arg):
-        return arg
-
-    assert bar(5) == 5
-    assert foo(5) == 5
-
-    bar = lambda arg: arg * 2
-
-    assert bar(5) == 10
-    assert foo(5) == 5
-
 def test_get_arg_spec():
     if is_py2:
         code = "def func(pos1, *args, **kwargs): pass"

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -15,6 +15,7 @@ __all__ = [
     "args",
     "response_handler",
     "error_handler",
+    "inject",
 ]
 
 
@@ -64,8 +65,8 @@ class MethodAnnotation(interfaces.Annotation):
     http_method_whitelist = None
 
     @classmethod
-    def is_static_call(cls, *args_, **kwargs):
-        if super(MethodAnnotation, cls).is_static_call(*args_, **kwargs):
+    def _is_static_call(cls, *args_, **kwargs):
+        if super(MethodAnnotation, cls)._is_static_call(*args_, **kwargs):
             return True
         try:
             is_class = inspect.isclass(args_[0])
@@ -157,7 +158,7 @@ class form_url_encoded(MethodAnnotation):
             def update_user(self, first_name: Field, last_name: Field):
                 \"""Update the current user.\"""
     """
-    can_be_static = True
+    _can_be_static = True
 
     # XXX: Let `requests` handle building urlencoded syntax.
     # def modify_request(self, request_builder):
@@ -183,7 +184,7 @@ class multipart(MethodAnnotation):
             def update_user(self, photo: Part, description: Part):
                 \"""Upload a user profile photo.\"""
     """
-    can_be_static = True
+    _can_be_static = True
 
     # XXX: Let `requests` handle building multipart syntax.
     # def modify_request(self, request_builder):
@@ -208,7 +209,7 @@ class json(MethodAnnotation):
             def update_user(self, **info: Body):
                 \"""Update the current user.\"""
     """
-    can_be_static = True
+    _can_be_static = True
 
     def modify_request(self, request_builder):
         """Modifies JSON request."""
@@ -332,8 +333,13 @@ class args(MethodAnnotation):
         self._helper(request_definition_builder.argument_handler_builder)
 
 
+class _InjectableMethodAnnotation(MethodAnnotation):
+    def modify_request(self, request_builder):
+        request_builder.add_transaction_hook(self)
+
+
 # noinspection PyPep8Naming
-class response_handler(MethodAnnotation, hooks.ResponseHandler):
+class response_handler(_InjectableMethodAnnotation, hooks.ResponseHandler):
     """
     A decorator for creating custom response handlers.
 
@@ -372,12 +378,9 @@ class response_handler(MethodAnnotation, hooks.ResponseHandler):
                ...
     """
 
-    def modify_request(self, request_builder):
-        request_builder.add_transaction_hook(self)
-
 
 # noinspection PyPep8Naming
-class error_handler(MethodAnnotation, hooks.ExceptionHandler):
+class error_handler(_InjectableMethodAnnotation, hooks.ExceptionHandler):
     """
     A decorator for creating custom error handlers.
 
@@ -421,5 +424,19 @@ class error_handler(MethodAnnotation, hooks.ExceptionHandler):
         original exception is thrown if the error handler doesn't throw
         anything.
     """
-    def modify_request(self, request_builder):
-        request_builder.add_transaction_hook(self)
+
+
+# noinspection PyPep8Naming
+class inject(_InjectableMethodAnnotation, hooks.TransactionHookChain):
+    """
+    A decorator that applies one or more hooks to a request method.
+
+    Example:
+        .. code-block:: python
+
+            @inject(Query("sort").equals("pushed"))
+            @get("users/{user}/repos")
+            def list_repos(self, user):
+                \"""Lists user's public repos by last pushed.\"""
+
+    """

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -438,5 +438,4 @@ class inject(_InjectableMethodAnnotation, hooks.TransactionHookChain):
             @get("users/{user}/repos")
             def list_repos(self, user):
                 \"""Lists user's public repos by last pushed.\"""
-
     """

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -437,5 +437,5 @@ class inject(_InjectableMethodAnnotation, hooks.TransactionHookChain):
             @inject(Query("sort").equals("pushed"))
             @get("users/{user}/repos")
             def list_repos(self, user):
-                \"""Lists user's public repos by last pushed.\"""
+                \"""Lists user's public repos by latest pushed.\"""
     """

--- a/uplink/helpers.py
+++ b/uplink/helpers.py
@@ -67,9 +67,6 @@ class RequestBuilder(object):
     def url(self, url):
         self._url = url
 
-    # TODO: Consider moving info out and having everything register a
-    #       transaction hook
-
     @property
     def info(self):
         return self._info

--- a/uplink/hooks.py
+++ b/uplink/hooks.py
@@ -51,8 +51,12 @@ class TransactionHookChain(TransactionHook):
     method on all hooks in the chain.
     """
 
-    def __init__(self, *hooks):
-        self._hooks = list(hooks)
+    def __init__(self, hook, *hooks):
+        self._hooks = (hook,)
+        if not hooks:
+            self.handle_response = hook.handle_response
+        else:
+            self._hooks += hooks
 
     def audit_request(self, *args, **kwargs):
         for hook in self._hooks:

--- a/uplink/interfaces.py
+++ b/uplink/interfaces.py
@@ -1,7 +1,6 @@
 class AnnotationMeta(type):
-
     def __call__(cls, *args, **kwargs):
-        if cls.can_be_static and cls.is_static_call(*args, **kwargs):
+        if cls._can_be_static and cls._is_static_call(*args, **kwargs):
             self = super(AnnotationMeta, cls).__call__()
             self(args[0])
             return args[0]
@@ -10,13 +9,13 @@ class AnnotationMeta(type):
 
 
 class _Annotation(object):
-    can_be_static = False
+    _can_be_static = False
 
     def modify_request_definition(self, request_definition_builder):
-        raise NotImplementedError
+        pass
 
     @classmethod
-    def is_static_call(cls, *args, **kwargs):
+    def _is_static_call(cls, *args, **kwargs):
         try:
             is_builder = isinstance(args[0], RequestDefinitionBuilder)
         except IndexError:

--- a/uplink/types.py
+++ b/uplink/types.py
@@ -224,6 +224,10 @@ class FuncDecoratorMixin(object):
             return super(FuncDecoratorMixin, self).__call__(obj)
 
     def equals(self, value):
+        """
+        Creates a transaction hook that sets this to the corresponding
+        value.
+        """
         auditor = functools.partial(self.modify_request, value=value)
         return hooks.RequestAuditor(auditor)
 

--- a/uplink/types.py
+++ b/uplink/types.py
@@ -4,10 +4,11 @@ handling classes.
 """
 # Standard library imports
 import collections
+import functools
 import inspect
 
 # Local imports
-from uplink import exceptions, interfaces, utils
+from uplink import exceptions, hooks, interfaces, utils
 from uplink.converters import keys
 
 __all__ = [
@@ -128,39 +129,28 @@ class ArgumentAnnotationHandler(interfaces.AnnotationHandler):
         return iter(self._arguments.values())
 
     def get_relevant_arguments(self, call_args):
-        return filter(call_args.__contains__, self._arguments)
+        annotations = self._arguments
+        return ((n, annotations[n]) for n in call_args if n in annotations)
 
     def handle_call(self, request_builder, args, kwargs):
         call_args = utils.get_call_args(self._func, None, *args, **kwargs)
-        for name in self.get_relevant_arguments(call_args):
-            self.handle_argument(
-                request_builder,
-                self._arguments[name],
-                call_args[name]
-            )
+        self.handle_call_args(request_builder, call_args)
 
-    @staticmethod
-    def handle_argument(request_builder, argument, value):
-        argument_type, converter_key = argument.type, argument.converter_key
-        converter = request_builder.get_converter(converter_key, argument_type)
-        value = converter.convert(value)
-
+    def handle_call_args(self, request_builder, call_args):
         # TODO: Catch Annotation errors and chain them here + provide context.
-        argument.modify_request(request_builder, value)
+        for name, annotation in self.get_relevant_arguments(call_args):
+            annotation.modify_request(request_builder, call_args[name])
 
 
 class ArgumentAnnotation(interfaces.Annotation):
-    can_be_static = True
+    _can_be_static = True
 
     def __call__(self, request_definition_builder):
         request_definition_builder.argument_handler_builder.add_annotation(self)
         return request_definition_builder
 
-    def modify_request_definition(self, definition_builder):  # pragma: no cover
+    def _modify_request(self, request_builder, value):  # pragma: no cover
         pass
-
-    def modify_request(self, request_builder, value):  # pragma: no cover
-        raise NotImplementedError
 
     @property
     def type(self):  # pragma: no cover
@@ -169,6 +159,12 @@ class ArgumentAnnotation(interfaces.Annotation):
     @property
     def converter_key(self):  # pragma: no cover
         raise NotImplementedError
+
+    def modify_request(self, request_builder, value):
+        argument_type, converter_key = self.type, self.converter_key
+        converter = request_builder.get_converter(converter_key, argument_type)
+        value = converter.convert(value)
+        self._modify_request(request_builder, value)
 
 
 class TypedArgument(ArgumentAnnotation):
@@ -184,12 +180,9 @@ class TypedArgument(ArgumentAnnotation):
     def converter_key(self):  # pragma: no cover
         raise NotImplementedError
 
-    def modify_request(self, request_builder, value):  # pragma: no cover
-        raise NotImplementedError
-
 
 class NamedArgument(TypedArgument):
-    can_be_static = True
+    _can_be_static = True
 
     def __init__(self, name=None, type=None):
         self._arg_name = name
@@ -210,14 +203,11 @@ class NamedArgument(TypedArgument):
     def converter_key(self):  # pragma: no cover
         raise NotImplementedError
 
-    def modify_request(self, request_builder, value):  # pragma: no cover
-        raise NotImplementedError
-
 
 class FuncDecoratorMixin(object):
     @classmethod
-    def is_static_call(cls, *args_, **kwargs):
-        if super(FuncDecoratorMixin, cls).is_static_call(*args_, **kwargs):
+    def _is_static_call(cls, *args_, **kwargs):
+        if super(FuncDecoratorMixin, cls)._is_static_call(*args_, **kwargs):
             return True
         try:
             is_func = inspect.isfunction(args_[0])
@@ -232,6 +222,10 @@ class FuncDecoratorMixin(object):
             return obj
         else:
             return super(FuncDecoratorMixin, self).__call__(obj)
+
+    def equals(self, value):
+        auditor = functools.partial(self.modify_request, value=value)
+        return hooks.RequestAuditor(auditor)
 
 
 class Path(NamedArgument):
@@ -277,7 +271,7 @@ class Path(NamedArgument):
     def modify_request_definition(self, request_definition_builder):
         request_definition_builder.uri.add_variable(self.name)
 
-    def modify_request(self, request_builder, value):
+    def _modify_request(self, request_builder, value):
         request_builder.url.set_variable({self.name: value})
 
 
@@ -348,7 +342,7 @@ class Query(FuncDecoratorMixin, NamedArgument):
         else:
             return keys.Sequence(keys.CONVERT_TO_STRING)
 
-    def modify_request(self, request_builder, value):
+    def _modify_request(self, request_builder, value):
         """Updates request body with the query parameter."""
         self.update_params(
             request_builder.info,
@@ -389,7 +383,7 @@ class QueryMap(FuncDecoratorMixin, TypedArgument):
         else:
             return keys.Map(keys.Sequence(keys.CONVERT_TO_STRING))
 
-    def modify_request(self, request_builder, value):
+    def _modify_request(self, request_builder, value):
         """Updates request body with the mapping of query args."""
         Query.update_params(request_builder.info, value, self._encoded)
 
@@ -415,7 +409,7 @@ class Header(FuncDecoratorMixin, NamedArgument):
         """Converts passed argument to string."""
         return keys.CONVERT_TO_STRING
 
-    def modify_request(self, request_builder, value):
+    def _modify_request(self, request_builder, value):
         """Updates request header contents."""
         request_builder.info["headers"][self.name] = value
 
@@ -429,7 +423,7 @@ class HeaderMap(FuncDecoratorMixin, TypedArgument):
         return keys.Map(keys.CONVERT_TO_STRING)
 
     @classmethod
-    def modify_request(cls, request_builder, value):
+    def _modify_request(cls, request_builder, value):
         """Updates request header contents."""
         request_builder.info["headers"].update(value)
 
@@ -466,7 +460,7 @@ class Field(NamedArgument):
         """Converts type to string."""
         return keys.CONVERT_TO_STRING
 
-    def modify_request(self, request_builder, value):
+    def _modify_request(self, request_builder, value):
         """Updates the request body with chosen field."""
         try:
             request_builder.info["data"][self.name] = value
@@ -505,7 +499,7 @@ class FieldMap(TypedArgument):
         """Converts type to string."""
         return keys.Map(keys.CONVERT_TO_STRING)
 
-    def modify_request(self, request_builder, value):
+    def _modify_request(self, request_builder, value):
         """Updates request body with chosen field mapping."""
         try:
             request_builder.info["data"].update(value)
@@ -535,7 +529,7 @@ class Part(NamedArgument):
         """Converts part to the request body."""
         return keys.CONVERT_TO_REQUEST_BODY
 
-    def modify_request(self, request_builder, value):
+    def _modify_request(self, request_builder, value):
         """Updates the request body with the form part."""
         request_builder.info["files"][self.name] = value
 
@@ -561,7 +555,7 @@ class PartMap(TypedArgument):
         """Converts each part to the request body."""
         return keys.Map(keys.CONVERT_TO_REQUEST_BODY)
 
-    def modify_request(self, request_builder, value):
+    def _modify_request(self, request_builder, value):
         """Updaytes request body to with the form parts."""
         request_builder.info["files"].update(value)
 
@@ -587,7 +581,7 @@ class Body(TypedArgument):
         """Converts request body."""
         return keys.CONVERT_TO_REQUEST_BODY
 
-    def modify_request(self, request_builder, value):
+    def _modify_request(self, request_builder, value):
         """Updates request body data."""
         request_builder.info["data"] = value
 
@@ -629,6 +623,6 @@ class Url(ArgumentAnnotation):
             raise self.DynamicUrlAssignmentFailed(request_definition_builder)
 
     @classmethod
-    def modify_request(cls, request_builder, value):
+    def _modify_request(cls, request_builder, value):
         """Updates request url."""
         request_builder.url = value

--- a/uplink/utils.py
+++ b/uplink/utils.py
@@ -59,18 +59,6 @@ try:
 except ImportError:
     import urlparse
 
-try:
-    from functools import lru_cache as memoize
-except ImportError:
-    def memoize():
-
-        def wrapper(func):
-            memo = {}
-            @wraps(func)
-            def wrapped(*args):
-                return memo.setdefault(args, func(*args))
-            return wrapped
-        return wrapper
 
 # Third party imports
 import uritemplate


### PR DESCRIPTION
Three changes proposed in this review. First, added the `equals` method for some argument annotations (e.g., `Query` and `Header`). This method takes a single argument, an acceptable value for the annotation, and creates a transaction hook that uses `ArgumentAnnotation.modify_request` to apply the annotation on a request. 

Second, added the `Consumer._inject` method. Can be used to add hooks in subclass constructors, for example.
```python
class GitHub(Consumer):
    def __init__(self, base_url, access_token):
        super(Consumer, self).__init__(base_url)
        self._inject(Query("access_token").equals(access_token))
```

Third, added the `inject` decorator. Can be used to add hooks on all invocations of a request method:
```python
@inject(Query("sort").equals("pushed"))
@get("users/{user}/repos")
def list_repos(self, user):
    """Lists user's public repos by last pushed."""
```