### PR TITLE
Set Fields of a Nested JSON Object in Payload 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Uplink turns your HTTP API into a Python class.
 
       @get("users/{user}/repos")
       def get_repos(self, user: Path, sort_by: Query("sort")):
-         """Fetches the user's public repositories."""
+         """Retrieves the user's public repositories."""
 
 Build an instance to interact with the webservice.
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,7 +1,11 @@
+# Standard library imports
+import collections
+
+# Third party imports
 import pytest
 
 # Local imports
-from uplink import decorators, interfaces
+from uplink import decorators
 
 
 @pytest.fixture
@@ -203,7 +207,9 @@ def test_json(request_builder):
         json.modify_request(request_builder)
 
     # Verify that error is raised when paths conflict
-    request_builder.info["data"] = {"key": "outer", ("key", "inner"): "inner"}
+    request_builder.info["data"] = body = collections.OrderedDict()
+    body["key"] = "outer"
+    body["key", "inner"] = "inner value"
     with pytest.raises(ValueError):
         json.modify_request(request_builder)
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -179,15 +179,17 @@ def test_multipart(request_builder):
 def test_json(request_builder):
     json = decorators.json()
 
-    # Verify without
-    json.modify_request(request_builder)
-    assert "json" not in request_builder.info
-
-    # Verify with
+    # Verify
     request_builder.info["data"] = {"field_name": "field_value"}
     json.modify_request(request_builder)
-    assert request_builder.info["json"] == {"field_name": "field_value"}
-    assert "data" not in request_builder.info
+    assert request_builder.info["data"] == {"field_name": "field_value"}
+
+    # Verify nested attribute
+    request_builder.info["data"] = {("outer", "inner"): "inner_value"}
+    json.modify_request(request_builder)
+    assert request_builder.info["data"] == {"outer": {"inner": "inner_value"}}
+
+    assert request_builder.add_transaction_hook.called
 
 
 def test_timeout(request_builder):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -57,6 +57,7 @@ class TestMethodAnnotationHandlerBuilder(object):
             method_level2
         ]
 
+
 class TestMethodAnnotationHandler(object):
 
     def test_handle_builder(self, request_builder, method_annotation_mock):
@@ -179,26 +180,20 @@ def test_multipart(request_builder):
 def test_json(request_builder):
     json = decorators.json()
 
-    # Check removal with nothing set yet
-    json._remove_data(request_builder)
-
     # Verify
     request_builder.info["data"] = {"field_name": "field_value"}
     json.modify_request(request_builder)
-    assert request_builder.info["data"] == {"field_name": "field_value"}
-    assert len(request_builder.info["data"]) == 1
+    assert request_builder.info["json"] == {"field_name": "field_value"}
+    assert len(request_builder.info["json"]) == 1
 
     # Check delete
-    del request_builder.info["data"]["field_name"]
-    assert len(request_builder.info["data"]) == 0
+    del request_builder.info["json"]["field_name"]
+    assert len(request_builder.info["json"]) == 0
+    assert "data" not in request_builder.info
 
     # Verify nested attribute
     request_builder.info["data"] = {("outer", "inner"): "inner_value"}
     json.modify_request(request_builder)
-    assert request_builder.info["data"] == {"outer": {"inner": "inner_value"}}
-
-    # Check removal
-    json._remove_data(request_builder)
     assert request_builder.info["json"] == {"outer": {"inner": "inner_value"}}
     assert "data" not in request_builder.info
 
@@ -208,13 +203,9 @@ def test_json(request_builder):
         json.modify_request(request_builder)
 
     # Verify that error is raised when paths conflict
-    request_builder.info["data"] = {}
-    json.modify_request(request_builder)
-    request_builder.info["data"]["key"] = "value"
+    request_builder.info["data"] = {"key": "outer", ("key", "inner"): "inner"}
     with pytest.raises(ValueError):
-        request_builder.info["data"]["key", "inner"] = "inner value"
-
-    assert request_builder.add_transaction_hook.called
+        json.modify_request(request_builder)
 
 
 def test_timeout(request_builder):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -292,7 +292,7 @@ class TestHeaderMap(ArgumentTestCase, FuncDecoratorTestCase):
 
 class TestField(ArgumentTestCase):
     type_cls = types.Field
-    expected_converter_key = keys.CONVERT_TO_STRING
+    expected_converter_key = keys.CONVERT_TO_REQUEST_BODY
 
     def test_modify_request(self, request_builder):
         types.Field("hello").modify_request(request_builder, "world")

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -268,20 +268,9 @@ class json(MethodAnnotation):
 
     def modify_request(self, request_builder):
         """Modifies JSON request."""
-        old_body = request_builder.info.get("data", {})
-        request_builder.info["data"] = self._JsonBody()
-        request_builder.info["data"].update(old_body)
-        request_builder.add_transaction_hook(
-            hooks.RequestAuditor(self._remove_data)
-        )
-
-    @staticmethod
-    def _remove_data(request_builder):
-        """Pops off the data map if it still exists."""
-        try:
-            request_builder.info["json"] = request_builder.info.pop("data")
-        except KeyError:
-            pass
+        old_body = request_builder.info.pop("data", {})
+        request_builder.info["json"] = self._JsonBody()
+        request_builder.info["json"].update(old_body)
 
 
 # noinspection PyPep8Naming

--- a/uplink/types.py
+++ b/uplink/types.py
@@ -465,8 +465,8 @@ class Field(NamedArgument):
 
     @property
     def converter_key(self):
-        """Converts type to string."""
-        return keys.CONVERT_TO_STRING
+        """Converts type to request body."""
+        return keys.CONVERT_TO_REQUEST_BODY
 
     def _modify_request(self, request_builder, value):
         """Updates the request body with chosen field."""
@@ -504,8 +504,8 @@ class FieldMap(TypedArgument):
 
     @property
     def converter_key(self):
-        """Converts type to string."""
-        return keys.Map(keys.CONVERT_TO_STRING)
+        """Converts type to request body."""
+        return keys.Map(keys.CONVERT_TO_REQUEST_BODY)
 
     def _modify_request(self, request_builder, value):
         """Updates request body with chosen field mapping."""
@@ -591,7 +591,8 @@ class Body(TypedArgument):
 
     def _modify_request(self, request_builder, value):
         """Updates request body data."""
-        request_builder.info["data"] = value
+        # TODO: Ensure that the body provides a mapping interface.
+        request_builder.info.setdefault("data", {}).update(value)
 
 
 class Url(ArgumentAnnotation):


### PR DESCRIPTION
These changes enable users to set nested JSON fields with `uplink.Field` and `uplink.json`. Tuples represent the path of nested field. For example, to achieve a payload like this:
```
{
   "user":  {
       "username": <<input value>>
   }
}
```

We can construct an `uplink.Field` with the `name` parameter set to the tuple `("outer", "inner")`, such as in the following example:

```python
@uplink.json
@uplink.post("/user")
def create_user(self, username: uplink.Field(("user", "username"))):
   pass
```