### PR TITLE
Introduce decorator to register default converters

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,6 @@ def uplink_builder_mock(mocker):
 def request_builder(mocker):
     builder = mocker.MagicMock(spec=helpers.RequestBuilder)
     builder.info = collections.defaultdict(dict)
-    builder.get_converter.return_value = converter_mock
-    converter_mock.convert = lambda x: x
+    builder.get_converter.return_value = lambda x: x
     return builder
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -86,7 +86,7 @@ class TestCallFactory(object):
 class TestBuilder(object):
     def test_init_adds_standard_converter_factory(self, uplink_builder):
         assert isinstance(
-            uplink_builder._converters[0],
+            uplink_builder.converters[-1],
             converters.StandardConverter
         )
 
@@ -105,7 +105,7 @@ class TestBuilder(object):
     def test_add_converter_factory(self,
                                    uplink_builder,
                                    converter_factory_mock):
-        uplink_builder.add_converter(converter_factory_mock)
+        uplink_builder.converters = (converter_factory_mock,)
         factory = list(uplink_builder.converters)[0]
         assert factory == converter_factory_mock
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -4,7 +4,7 @@ import pytest
 
 # Local imports
 from uplink import converters
-from uplink.converters import standard
+from uplink.converters import register, standard
 
 
 class TestCast(object):
@@ -230,3 +230,30 @@ class TestSequence(object):
 
         # Verify
         assert value == "1"
+
+
+class TestRegistry(object):
+
+    @pytest.mark.parametrize(
+        "converter",
+        # Try with both class and instance
+        (converters.StandardConverter, converters.StandardConverter())
+    )
+    def test_register_converter_factory_pass(self, converter):
+        # Setup
+        registry = register.FactoryRegistry()
+
+        # Verify
+        return_value = registry.register_converter_factory(converter)
+        defaults = registry.get_default_converter_factories()
+        assert return_value is converter
+        assert len(defaults) == 1
+        assert isinstance(defaults[0], converters.StandardConverter)
+
+    def test_register_converter_factory_pass(self):
+        # Setup
+        registry = register.FactoryRegistry()
+
+        # Verify failure when registered factory is not proper type.
+        with pytest.raises(TypeError):
+            registry.register_converter_factory(object())

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -4,40 +4,42 @@ import pytest
 
 # Local imports
 from uplink import converters
+from uplink.converters import standard
 
 
 class TestCast(object):
-    def test_converter_without_caster(self, converter_mock):
-        converter_mock.convert.return_value = 2
-        cast = converters.Cast(None, converter_mock)
+    def test_converter_without_caster(self, mocker):
+        converter_mock = mocker.stub()
+        converter_mock.return_value = 2
+        cast = standard.Cast(None, converter_mock)
         return_value = cast.convert(1)
-        converter_mock.convert.assert_called_with(1)
+        converter_mock.assert_called_with(1)
         assert return_value == 2
 
-    def test_convert_with_caster(self, mocker, converter_mock):
+    def test_convert_with_caster(self, mocker):
         caster = mocker.Mock(return_value=2)
-        converter_mock.convert.return_value = 3
-        cast = converters.Cast(caster, converter_mock)
+        converter_mock = mocker.Mock(return_value=3)
+        cast = standard.Cast(caster, converter_mock)
         return_value = cast.convert(1)
         caster.assert_called_with(1)
-        converter_mock.convert.assert_called_with(2)
+        converter_mock.assert_called_with(2)
         assert return_value == 3
 
 
 class TestRequestBodyConverter(object):
     def test_convert_str(self):
-        converter_ = converters.RequestBodyConverter()
+        converter_ = standard.RequestBodyConverter()
         assert converter_.convert("example") == "example"
 
     def test_convert_obj(self):
-        converter_ = converters.RequestBodyConverter()
+        converter_ = standard.RequestBodyConverter()
         example = {"hello": "2"}
         assert converter_.convert(example) == example
 
 
 class TestStringConverter(object):
     def test_convert(self):
-        converter_ = converters.StringConverter()
+        converter_ = standard.StringConverter()
         assert converter_.convert(2) == "2"
 
 
@@ -178,7 +180,7 @@ class TestMarshmallowConverter(object):
         converter = converters.MarshmallowConverter()
 
         # Run
-        c = converter.make_string_converter(argument)
+        c = converter.make_string_converter(argument, None, None)
 
         # Verify
         assert c is None
@@ -194,7 +196,7 @@ class TestMap(object):
 
         # Run
         converter = registry[key](None)
-        value = converter.convert({"hello": 1})
+        value = converter({"hello": 1})
 
         # Verify
         assert value == {"hello": "1"}
@@ -210,7 +212,7 @@ class TestSequence(object):
 
         # Run
         converter = registry[key](None)
-        value = converter.convert([1, 2, 3])
+        value = converter([1, 2, 3])
 
         # Verify
         assert value == ["1", "2", "3"]
@@ -224,7 +226,7 @@ class TestSequence(object):
 
         # Run
         converter = registry[key](None)
-        value = converter.convert("1")
+        value = converter("1")
 
         # Verify
         assert value == "1"

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -185,6 +185,26 @@ class TestMarshmallowConverter(object):
         # Verify
         assert c is None
 
+    def test_register(self, mocker):
+        # Setup
+        converter = converters.MarshmallowConverter
+        old_marshmallow = converter.marshmallow
+
+        # Run & Verify: Register when marshmallow is installed
+        converter.marshmallow = True
+        register_ = mocker.Mock(spec=register.Register())
+        converter.register_if_necessary(register_)
+        register_.register_converter_factory.assert_called_with(converter)
+
+        # Run & Verify: Skip when marshmallow is not installed
+        converter.marshmallow = None
+        register_ = mocker.Mock(spec=register.Register())
+        converter.register_if_necessary(register_)
+        assert not register_.register_converter_factory.called
+
+        # Rewire
+        converters.MarshmallowConverter.marshmallow = old_marshmallow
+
 
 class TestMap(object):
     def test_convert(self):
@@ -200,6 +220,11 @@ class TestMap(object):
 
         # Verify
         assert value == {"hello": "1"}
+
+    def test_eq(self):
+        assert converters.keys.Map(0) == converters.keys.Map(0)
+        assert not (converters.keys.Map(1) == converters.keys.Map(0))
+        assert not (converters.keys.Map(1) == 1)
 
 
 class TestSequence(object):
@@ -230,6 +255,11 @@ class TestSequence(object):
 
         # Verify
         assert value == "1"
+
+    def test_eq(self):
+        assert converters.keys.Sequence(0) == converters.keys.Sequence(0)
+        assert not (converters.keys.Sequence(1) == converters.keys.Sequence(0))
+        assert not (converters.keys.Sequence(1) == 1)
 
 
 class TestRegistry(object):

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -241,18 +241,18 @@ class TestRegistry(object):
     )
     def test_register_converter_factory_pass(self, converter):
         # Setup
-        registry = register.FactoryRegistry()
+        registry = register.Register()
 
         # Verify
         return_value = registry.register_converter_factory(converter)
-        defaults = registry.get_default_converter_factories()
+        defaults = registry.get_converter_factories()
         assert return_value is converter
         assert len(defaults) == 1
         assert isinstance(defaults[0], converters.StandardConverter)
 
     def test_register_converter_factory_pass(self):
         # Setup
-        registry = register.FactoryRegistry()
+        registry = register.Register()
 
         # Verify failure when registered factory is not proper type.
         with pytest.raises(TypeError):

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -43,6 +43,19 @@ class TestStringConverter(object):
         assert converter_.convert(2) == "2"
 
 
+class TestStandardConverter(object):
+    def test_make_response_body_converter(self):
+        # Setup
+        converter = standard.StandardConverter()
+
+        # Run & Verify: Pass-through callables
+        def f(_): pass
+        assert f is converter.make_response_body_converter(f)
+
+        # Run & Verify: Otherwise, return None
+        assert None is converter.make_response_body_converter("converter")
+
+
 class TestConverterFactoryRegistry(object):
     backend = converters.ConverterFactoryRegistry._converter_factory_registry
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -151,10 +151,9 @@ class TestArgumentAnnotationHandler(object):
         relevant = annotation_handler.get_relevant_arguments(args)
         assert list(relevant) == list(args.items())
 
-    def test_handle_call(self, request_builder, converter_mock, mocker):
+    def test_handle_call(self, request_builder, mocker):
         def dummy(arg1): return arg1
-        request_builder.get_converter.return_value = converter_mock
-        converter_mock.convert = dummy
+        request_builder.get_converter.return_value = dummy
         get_call_args = mocker.patch("uplink.utils.get_call_args")
         get_call_args.return_value = {"arg1": "hello"}
         annotation = mocker.Mock(types.ArgumentAnnotation)

--- a/uplink/clients/twisted_.py
+++ b/uplink/clients/twisted_.py
@@ -6,7 +6,7 @@ returns :py:class:`twisted.internet.defer.Deferred` responses.
 # Third party imports
 try:
     from twisted.internet import threads
-except ImportError:
+except ImportError:  # pragma: no cover
     threads = None
 
 # Local imports

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -179,7 +179,7 @@ class RequestDefinition(interfaces.RequestDefinition):
         return converters.ConverterFactoryRegistry(
             converters_,
             argument_annotations=self.argument_annotations,
-            request_annotations=self.method_annotations
+            method_annotations=self.method_annotations
         )
 
     def define_request(self, request_builder, func_args, func_kwargs):

--- a/uplink/converters/__init__.py
+++ b/uplink/converters/__init__.py
@@ -1,56 +1,33 @@
 # Standard library imports
 import collections
 import functools
-import json
 
 # Local imports
 from uplink.converters import interfaces, keys
+from uplink.converters.register import (
+    get_default_converter_factories,
+    register_converter_factory
+)
+
+# Default converters - load standard first so it's ensured to be the
+# last in the converter chain.
+from uplink.converters.standard import StandardConverter
 from uplink.converters.marshmallow_ import MarshmallowConverter
 
-__all__ = ["StandardConverter", "MarshmallowConverter"]
+__all__ = [
+    "register_converter_factory",
+    "MarshmallowConverter"
+]
 
 
-class Cast(interfaces.Converter):
-    def __init__(self, caster, converter):
-        self._cast = caster
-        self._converter = converter
+class ConverterChain(object):
 
-    def convert(self, value):
-        if callable(self._cast):
-            value = self._cast(value)
-        return self._converter.convert(value)
+    def __init__(self, converter_factory):
+        self._converter_factory = converter_factory
 
-
-class RequestBodyConverter(interfaces.Converter):
-    def convert(self, value):
-        if isinstance(value, str):
-            return value
-        else:
-            return json.loads(
-                json.dumps(value, default=lambda obj: obj.__dict__)
-            )
-
-
-class StringConverter(interfaces.Converter):
-    def convert(self, value):
-        return str(value)
-
-
-class StandardConverter(interfaces.ConverterFactory):
-    """
-    The default converter, this class seeks to provide sane alternatives
-    for (de)serialization when all else fails -- e.g., no other
-    converters could handle a particular type.
-    """
-
-    def make_response_body_converter(self, type_, *args, **kwargs):
-        return None  # pragma: no cover
-
-    def make_request_body_converter(self, type_, *args, **kwargs):
-        return Cast(type_, RequestBodyConverter())  # pragma: no cover
-
-    def make_string_converter(self, type_, *args, **kwargs):
-        return Cast(type_, StringConverter())  # pragma: no cover
+    def __call__(self, *args, **kwargs):
+        converter = self._converter_factory(*args, **kwargs)
+        return converter
 
 
 class ConverterFactoryRegistry(collections.Mapping):
@@ -83,14 +60,13 @@ class ConverterFactoryRegistry(collections.Mapping):
             appear earlier in the chain are given the opportunity to
             handle a request before those that appear later.
     """
-
     #: A mapping of keys to callables. Each callable value accepts a
     #: single argument, a :py:class:`interfaces.ConverterFactory`
     #: subclass, and returns another callable, which should return a
     #: :py:`interfaces.Converter` instance.
     _converter_factory_registry = {}
 
-    def __init__(self, factories, *args, **kwargs):
+    def __init__(self, factories=(), *args, **kwargs):
         self._factories = tuple(factories)
         self._args = args
         self._kwargs = kwargs
@@ -108,7 +84,9 @@ class ConverterFactoryRegistry(collections.Mapping):
                 converter = func(factory)(*args, **kwargs)
                 if converter is not None:
                     return converter
-        return functools.partial(chain, *self._args, **self._kwargs)
+        return ConverterChain(
+            functools.partial(chain, *self._args, **self._kwargs)
+        )
 
     def _make_chain_for_key(self, converter_key):
         return self._make_chain_for_func(

--- a/uplink/converters/interfaces.py
+++ b/uplink/converters/interfaces.py
@@ -3,17 +3,21 @@ class Converter(object):
     def convert(self, value):
         raise NotImplementedError
 
+    def __call__(self, *args, **kwargs):
+        return self.convert(*args, **kwargs)
+
 
 class ConverterFactory(object):
 
     def make_response_body_converter(self, type_, argument_annotations,
                                      method_annotations):
-        raise NotImplementedError
+        pass
 
     def make_request_body_converter(self, type_, argument_annotations,
                                     method_annotations):
-        raise NotImplementedError
+        pass
 
     def make_string_converter(self, type_, argument_annotations,
                               method_annotations):
+        pass
         raise NotImplementedError

--- a/uplink/converters/interfaces.py
+++ b/uplink/converters/interfaces.py
@@ -20,4 +20,3 @@ class ConverterFactory(object):
     def make_string_converter(self, type_, argument_annotations,
                               method_annotations):
         pass
-        raise NotImplementedError

--- a/uplink/converters/keys.py
+++ b/uplink/converters/keys.py
@@ -34,13 +34,6 @@ class CompositeKey(object):
     Arguments:
         converter_key: The enveloped converter key.
     """
-    class ConverterUsingFunction(interfaces.Converter):
-        def __init__(self, convert_function):
-            self._convert = convert_function
-
-        def convert(self, value):
-            return self._convert(value)
-
     def __init__(self, converter_key):
         self._converter_key = converter_key
 
@@ -57,8 +50,7 @@ class CompositeKey(object):
 
         def factory_wrapper(*args, **kwargs):
             converter = factory(*args, **kwargs)
-            convert_func = functools.partial(self.convert, converter)
-            return self.ConverterUsingFunction(convert_func)
+            return functools.partial(self.convert, converter)
 
         return factory_wrapper
 
@@ -74,7 +66,7 @@ class Map(CompositeKey):
         Map(CONVERT_TO_STRING)
     """
     def convert(self, converter, value):
-        return dict((k, converter.convert(value[k])) for k in value)
+        return dict((k, converter(value[k])) for k in value)
 
 
 class Sequence(CompositeKey):
@@ -89,6 +81,6 @@ class Sequence(CompositeKey):
     """
     def convert(self, converter, value):
         if isinstance(value, (list, tuple)):
-            return list(map(converter.convert, value))
+            return list(map(converter, value))
         else:
-            return converter.convert(value)
+            return converter(value)

--- a/uplink/converters/marshmallow_.py
+++ b/uplink/converters/marshmallow_.py
@@ -7,7 +7,7 @@ to deserialize and serialize values.
 import inspect
 
 # Local imports
-from uplink.converters import interfaces
+from uplink.converters import interfaces, register
 
 
 class MarshmallowConverter(interfaces.ConverterFactory):
@@ -39,6 +39,7 @@ class MarshmallowConverter(interfaces.ConverterFactory):
 
             $ pip install uplink[marshmallow]
     """
+
     try:
         import marshmallow
     except ImportError:  # pragma: no cover
@@ -102,5 +103,6 @@ class MarshmallowConverter(interfaces.ConverterFactory):
         """
         return self._make_converter(self.ResponseBodyConverter, type_)
 
-    def make_string_converter(self, type_, *args, **kwargs):
-        return None
+
+if MarshmallowConverter.marshmallow is not None:
+    register.register_converter_factory(MarshmallowConverter)

--- a/uplink/converters/marshmallow_.py
+++ b/uplink/converters/marshmallow_.py
@@ -103,6 +103,10 @@ class MarshmallowConverter(interfaces.ConverterFactory):
         """
         return self._make_converter(self.ResponseBodyConverter, type_)
 
+    @classmethod
+    def register_if_necessary(cls, register_):
+        if cls.marshmallow is not None:
+            register_.register_converter_factory(cls)
 
-if MarshmallowConverter.marshmallow is not None:
-    register.register_converter_factory(MarshmallowConverter)
+
+MarshmallowConverter.register_if_necessary(register)

--- a/uplink/converters/register.py
+++ b/uplink/converters/register.py
@@ -5,7 +5,7 @@ import collections
 from uplink.converters import interfaces
 
 
-class FactoryRegistry(object):
+class Register(object):
 
     def __init__(self):
         self._register = collections.deque()
@@ -14,18 +14,18 @@ class FactoryRegistry(object):
         factory = factory_proxy() if callable(factory_proxy) else factory_proxy
         if not isinstance(factory, interfaces.ConverterFactory):
             raise TypeError(
-                "Failed to register '%s' as converter factory: it is not an "
+                "Failed to register '%s' as a converter factory: it is not an "
                 "instance of '%s'." % (factory, interfaces.ConverterFactory)
             )
         self._register.appendleft(factory)
         return factory_proxy
 
-    def get_default_converter_factories(self):
+    def get_converter_factories(self):
         return tuple(self._register)
 
 
-_registry = FactoryRegistry()
+_registry = Register()
 
 register_converter_factory = _registry.register_converter_factory
-get_default_converter_factories = _registry.get_default_converter_factories
+get_default_converter_factories = _registry.get_converter_factories
 

--- a/uplink/converters/register.py
+++ b/uplink/converters/register.py
@@ -1,0 +1,22 @@
+# Standard library imports
+import collections
+
+# Local imports
+from uplink.converters import interfaces
+
+_default_converter_factories = collections.deque()
+
+
+def register_converter_factory(factory_proxy):
+    factory = factory_proxy() if callable(factory_proxy) else factory_proxy
+    if not isinstance(factory, interfaces.ConverterFactory):
+        raise TypeError(
+            "Failed to register '%s' as converter factory: it is not an "
+            "instance of '%s'." % (factory, interfaces.ConverterFactory)
+        )
+    _default_converter_factories.appendleft(factory)
+    return factory_proxy
+
+
+def get_default_converter_factories():
+    return tuple(_default_converter_factories)

--- a/uplink/converters/standard.py
+++ b/uplink/converters/standard.py
@@ -1,0 +1,50 @@
+# Standard library imports
+import json
+
+# Local imports
+from uplink.converters import interfaces, register
+
+
+class Cast(interfaces.Converter):
+    def __init__(self, caster, converter):
+        self._cast = caster
+        self._converter = converter
+
+    def convert(self, value):
+        if callable(self._cast):
+            value = self._cast(value)
+        return self._converter(value)
+
+
+class RequestBodyConverter(interfaces.Converter):
+    def convert(self, value):
+        if isinstance(value, str):
+            return value
+        else:
+            return json.loads(
+                json.dumps(value, default=lambda obj: obj.__dict__)
+            )
+
+
+class StringConverter(interfaces.Converter):
+    def convert(self, value):
+        return str(value)
+
+
+@register.register_converter_factory
+class StandardConverter(interfaces.ConverterFactory):
+    """
+    The default converter, this class seeks to provide sane alternatives
+    for (de)serialization when all else fails -- e.g., no other
+    converters could handle a particular type.
+    """
+
+    def make_response_body_converter(self, type_, *args, **kwargs):
+        if callable(type_):
+            return type_
+
+    def make_request_body_converter(self, type_, *args, **kwargs):
+        return Cast(type_, RequestBodyConverter())  # pragma: no cover
+
+    def make_string_converter(self, type_, *args, **kwargs):
+        return Cast(type_, StringConverter())  # pragma: no cover

--- a/uplink/converters/standard.py
+++ b/uplink/converters/standard.py
@@ -17,13 +17,16 @@ class Cast(interfaces.Converter):
 
 
 class RequestBodyConverter(interfaces.Converter):
+
+    @staticmethod
+    def _default_json_dumper(obj):
+        return obj.__dict__  # pragma: no cover
+
     def convert(self, value):
         if isinstance(value, str):
             return value
-        else:
-            return json.loads(
-                json.dumps(value, default=lambda obj: obj.__dict__)
-            )
+        dumped = json.dumps(value, default=self._default_json_dumper)
+        return json.loads(dumped)
 
 
 class StringConverter(interfaces.Converter):

--- a/uplink/types.py
+++ b/uplink/types.py
@@ -163,8 +163,7 @@ class ArgumentAnnotation(interfaces.Annotation):
     def modify_request(self, request_builder, value):
         argument_type, converter_key = self.type, self.converter_key
         converter = request_builder.get_converter(converter_key, argument_type)
-        value = converter.convert(value)
-        self._modify_request(request_builder, value)
+        self._modify_request(request_builder, converter(value))
 
 
 class TypedArgument(ArgumentAnnotation):


### PR DESCRIPTION
Here's are some key changes included in these commits:
* Added `register_converter_factory` decorator to register default converters. These converter factories are always used. 
* `MarshmallowConverter` is registered as a default converter if `marshmallow` is installed. This avoids the extra step of having users specify the converter when constructing a new consumer.