### PR TITLE
Add converter that can handle type hints (PEP-0484)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,8 +81,7 @@ Extra! Extra!
 Further, uplink has optional integrations and features. You can view a full list 
 of available extras `here <http://uplink.readthedocs.io/en/latest/install.html#extras>`_.
 
-When installing Uplink with ``pip``, you can specify any number of extras
-using the format:
+When installing Uplink with ``pip``, you can select extras using the format:
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Extra! Extra!
 Further, uplink has optional integrations and features. You can view a full list 
 of available extras `here <http://uplink.readthedocs.io/en/latest/install.html#extras>`_.
 
-When installing Uplink with ``pip``, you can specify any of number of extras
+When installing Uplink with ``pip``, you can specify any number of extras
 using the format:
 
 ::

--- a/requirements.d/tests.txt
+++ b/requirements.d/tests.txt
@@ -9,6 +9,9 @@ aiohttp==2.3.0; python_version >= '3.4'
 # Marshmallow Support
 marshmallow==2.15.0
 
+# Typing Support
+typing==3.6.4
+
 # Testing
 pytest==3.2.1
 pytest-mock==1.6.2

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ install_requires = [
 extras_require = {
     "aiohttp": ["aiohttp>=2.3.0"],
     "twisted": ["twisted>=17.1.0"],
-    "marshmallow": ["marshmallow>=2.15.0"]
+    "marshmallow": ["marshmallow>=2.15.0"],
+    "typing": ["typing>=3.6.4"]
 }
 
 metadata = dict({

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,6 @@ def uplink_builder_mock(mocker):
 def request_builder(mocker):
     builder = mocker.MagicMock(spec=helpers.RequestBuilder)
     builder.info = collections.defaultdict(dict)
-    builder.get_converter.return_value = converter_mock
-    converter_mock.convert = lambda x: x
+    builder.get_converter.return_value = lambda x: x
     return builder
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -86,7 +86,7 @@ class TestCallFactory(object):
 class TestBuilder(object):
     def test_init_adds_standard_converter_factory(self, uplink_builder):
         assert isinstance(
-            uplink_builder._converters[0],
+            uplink_builder.converters[-1],
             converters.StandardConverter
         )
 
@@ -105,7 +105,7 @@ class TestBuilder(object):
     def test_add_converter_factory(self,
                                    uplink_builder,
                                    converter_factory_mock):
-        uplink_builder.add_converter(converter_factory_mock)
+        uplink_builder.converters = (converter_factory_mock,)
         factory = list(uplink_builder.converters)[0]
         assert factory == converter_factory_mock
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -4,40 +4,42 @@ import pytest
 
 # Local imports
 from uplink import converters
+from uplink.converters import standard
 
 
 class TestCast(object):
-    def test_converter_without_caster(self, converter_mock):
-        converter_mock.convert.return_value = 2
-        cast = converters.Cast(None, converter_mock)
+    def test_converter_without_caster(self, mocker):
+        converter_mock = mocker.stub()
+        converter_mock.return_value = 2
+        cast = standard.Cast(None, converter_mock)
         return_value = cast.convert(1)
-        converter_mock.convert.assert_called_with(1)
+        converter_mock.assert_called_with(1)
         assert return_value == 2
 
-    def test_convert_with_caster(self, mocker, converter_mock):
+    def test_convert_with_caster(self, mocker):
         caster = mocker.Mock(return_value=2)
-        converter_mock.convert.return_value = 3
-        cast = converters.Cast(caster, converter_mock)
+        converter_mock = mocker.Mock(return_value=3)
+        cast = standard.Cast(caster, converter_mock)
         return_value = cast.convert(1)
         caster.assert_called_with(1)
-        converter_mock.convert.assert_called_with(2)
+        converter_mock.assert_called_with(2)
         assert return_value == 3
 
 
 class TestRequestBodyConverter(object):
     def test_convert_str(self):
-        converter_ = converters.RequestBodyConverter()
+        converter_ = standard.RequestBodyConverter()
         assert converter_.convert("example") == "example"
 
     def test_convert_obj(self):
-        converter_ = converters.RequestBodyConverter()
+        converter_ = standard.RequestBodyConverter()
         example = {"hello": "2"}
         assert converter_.convert(example) == example
 
 
 class TestStringConverter(object):
     def test_convert(self):
-        converter_ = converters.StringConverter()
+        converter_ = standard.StringConverter()
         assert converter_.convert(2) == "2"
 
 
@@ -178,7 +180,7 @@ class TestMarshmallowConverter(object):
         converter = converters.MarshmallowConverter()
 
         # Run
-        c = converter.make_string_converter(argument)
+        c = converter.make_string_converter(argument, None, None)
 
         # Verify
         assert c is None
@@ -194,7 +196,7 @@ class TestMap(object):
 
         # Run
         converter = registry[key](None)
-        value = converter.convert({"hello": 1})
+        value = converter({"hello": 1})
 
         # Verify
         assert value == {"hello": "1"}
@@ -210,7 +212,7 @@ class TestSequence(object):
 
         # Run
         converter = registry[key](None)
-        value = converter.convert([1, 2, 3])
+        value = converter([1, 2, 3])
 
         # Verify
         assert value == ["1", "2", "3"]
@@ -224,7 +226,7 @@ class TestSequence(object):
 
         # Run
         converter = registry[key](None)
-        value = converter.convert("1")
+        value = converter("1")
 
         # Verify
         assert value == "1"

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -49,24 +49,23 @@ class TestStringConverter(object):
 class TestConverterFactoryRegistry(object):
     backend = converters.ConverterFactoryRegistry._converter_factory_registry
 
-    def test_init_args_are_passed_to_factory(self, converter_factory_mock):
+    def test_init_args_are_passed_to_factory(self, converter_factory_mock, converter_mock):
         args = ("arg1", "arg2")
         kwargs = {"arg3": "arg3"}
-        converter_factory_mock.make_string_converter.return_value = "test"
+        converter_factory_mock.make_string_converter.return_value = converter_mock
         registry = converters.ConverterFactoryRegistry(
             (converter_factory_mock,), *args, **kwargs)
         return_value = registry[converters.keys.CONVERT_TO_STRING]()
         converter_factory_mock.make_string_converter.assert_called_with(
             *args, **kwargs
         )
-        assert return_value == "test"
+        assert return_value is converter_mock
 
-    def test_converters_require_chain(self, converter_factory_mock, mocker):
-        requires_chain = mocker.Mock(spec=converters.interfaces.RequiresChain)
-        converter_factory_mock.make_string_converter.return_value = requires_chain
+    def test_hooks(self, converter_factory_mock, converter_mock):
+        converter_factory_mock.make_string_converter.return_value = converter_mock
         registry = converters.ConverterFactoryRegistry((converter_factory_mock,))
         registry[converters.keys.CONVERT_TO_STRING]()
-        assert requires_chain.set_chain.called
+        assert converter_mock.set_chain.called
 
     def test_len(self):
         registry = converters.ConverterFactoryRegistry(())

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -201,6 +201,14 @@ def test_returns(request_builder):
     returns.modify_request(request_builder)
     assert request_builder.return_type is str
 
+    returns = decorators.returns.list(str)
+    returns.modify_request(request_builder)
+    assert request_builder.return_type == returns.List[str]
+
+    returns = decorators.returns.dict(str, str)
+    returns.modify_request(request_builder)
+    assert request_builder.return_type == returns.Dict[str, str]
+
 
 def test_args(request_definition_builder):
     args = decorators.args(str, str, name=str)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -151,10 +151,9 @@ class TestArgumentAnnotationHandler(object):
         relevant = annotation_handler.get_relevant_arguments(args)
         assert list(relevant) == list(args.items())
 
-    def test_handle_call(self, request_builder, converter_mock, mocker):
+    def test_handle_call(self, request_builder, mocker):
         def dummy(arg1): return arg1
-        request_builder.get_converter.return_value = converter_mock
-        converter_mock.convert = dummy
+        request_builder.get_converter.return_value = dummy
         get_call_args = mocker.patch("uplink.utils.get_call_args")
         get_call_args.return_value = {"arg1": "hello"}
         annotation = mocker.Mock(types.ArgumentAnnotation)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -60,7 +60,13 @@ class FuncDecoratorTestCase(object):
 
 
 class TestArgumentAnnotationHandlerBuilder(object):
-    
+
+    def test_from_func(self):
+        def func(_): pass
+        handler = types.ArgumentAnnotationHandlerBuilder.from_func(func)
+        another_handler = types.ArgumentAnnotationHandlerBuilder.from_func(func)
+        assert handler is another_handler
+
     @inject_args
     def test_missing_arguments(self, args):
         builder = types.ArgumentAnnotationHandlerBuilder(None, args, False)

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -179,7 +179,7 @@ class RequestDefinition(interfaces.RequestDefinition):
         return converters.ConverterFactoryRegistry(
             converters_,
             argument_annotations=self.argument_annotations,
-            request_annotations=self.method_annotations
+            method_annotations=self.method_annotations
         )
 
     def define_request(self, request_builder, func_args, func_kwargs):

--- a/uplink/converters/__init__.py
+++ b/uplink/converters/__init__.py
@@ -1,56 +1,33 @@
 # Standard library imports
 import collections
 import functools
-import json
 
 # Local imports
 from uplink.converters import interfaces, keys
+from uplink.converters.register import (
+    get_default_converter_factories,
+    register_converter_factory
+)
+
+# Default converters - load standard first so it's ensured to be the
+# last in the converter chain.
+from uplink.converters.standard import StandardConverter
 from uplink.converters.marshmallow_ import MarshmallowConverter
 
-__all__ = ["StandardConverter", "MarshmallowConverter"]
+__all__ = [
+    "register_converter_factory",
+    "MarshmallowConverter"
+]
 
 
-class Cast(interfaces.Converter):
-    def __init__(self, caster, converter):
-        self._cast = caster
-        self._converter = converter
+class ConverterChain(object):
 
-    def convert(self, value):
-        if callable(self._cast):
-            value = self._cast(value)
-        return self._converter.convert(value)
+    def __init__(self, converter_factory):
+        self._converter_factory = converter_factory
 
-
-class RequestBodyConverter(interfaces.Converter):
-    def convert(self, value):
-        if isinstance(value, str):
-            return value
-        else:
-            return json.loads(
-                json.dumps(value, default=lambda obj: obj.__dict__)
-            )
-
-
-class StringConverter(interfaces.Converter):
-    def convert(self, value):
-        return str(value)
-
-
-class StandardConverter(interfaces.ConverterFactory):
-    """
-    The default converter, this class seeks to provide sane alternatives
-    for (de)serialization when all else fails -- e.g., no other
-    converters could handle a particular type.
-    """
-
-    def make_response_body_converter(self, type_, *args, **kwargs):
-        return None  # pragma: no cover
-
-    def make_request_body_converter(self, type_, *args, **kwargs):
-        return Cast(type_, RequestBodyConverter())  # pragma: no cover
-
-    def make_string_converter(self, type_, *args, **kwargs):
-        return Cast(type_, StringConverter())  # pragma: no cover
+    def __call__(self, *args, **kwargs):
+        converter = self._converter_factory(*args, **kwargs)
+        return converter
 
 
 class ConverterFactoryRegistry(collections.Mapping):
@@ -83,14 +60,13 @@ class ConverterFactoryRegistry(collections.Mapping):
             appear earlier in the chain are given the opportunity to
             handle a request before those that appear later.
     """
-
     #: A mapping of keys to callables. Each callable value accepts a
     #: single argument, a :py:class:`interfaces.ConverterFactory`
     #: subclass, and returns another callable, which should return a
     #: :py:`interfaces.Converter` instance.
     _converter_factory_registry = {}
 
-    def __init__(self, factories, *args, **kwargs):
+    def __init__(self, factories=(), *args, **kwargs):
         self._factories = tuple(factories)
         self._args = args
         self._kwargs = kwargs
@@ -108,7 +84,9 @@ class ConverterFactoryRegistry(collections.Mapping):
                 converter = func(factory)(*args, **kwargs)
                 if converter is not None:
                     return converter
-        return functools.partial(chain, *self._args, **self._kwargs)
+        return ConverterChain(
+            functools.partial(chain, *self._args, **self._kwargs)
+        )
 
     def _make_chain_for_key(self, converter_key):
         return self._make_chain_for_func(

--- a/uplink/converters/__init__.py
+++ b/uplink/converters/__init__.py
@@ -13,6 +13,7 @@ from uplink.converters.register import (
 # last in the converter chain.
 from uplink.converters.standard import StandardConverter
 from uplink.converters.marshmallow_ import MarshmallowConverter
+from uplink.converters.typing_ import TypingConverter
 
 __all__ = [
     "register_converter_factory",
@@ -27,6 +28,8 @@ class ConverterChain(object):
 
     def __call__(self, *args, **kwargs):
         converter = self._converter_factory(*args, **kwargs)
+        if isinstance(converter, interfaces.RequiresChain):
+            converter.set_chain(self)
         return converter
 
 

--- a/uplink/converters/__init__.py
+++ b/uplink/converters/__init__.py
@@ -4,6 +4,7 @@ import functools
 
 # Local imports
 from uplink.converters import interfaces, keys
+from uplink.converters.interfaces import ConverterFactory, Converter
 from uplink.converters.register import (
     get_default_converter_factories,
     register_converter_factory
@@ -28,7 +29,7 @@ class ConverterChain(object):
 
     def __call__(self, *args, **kwargs):
         converter = self._converter_factory(*args, **kwargs)
-        if isinstance(converter, interfaces.RequiresChain):
+        if isinstance(converter, interfaces.Converter):
             converter.set_chain(self)
         return converter
 
@@ -85,7 +86,7 @@ class ConverterFactoryRegistry(collections.Mapping):
         def chain(*args, **kwargs):
             for factory in self.factories:
                 converter = func(factory)(*args, **kwargs)
-                if converter is not None:
+                if callable(converter):
                     return converter
         return ConverterChain(
             functools.partial(chain, *self._args, **self._kwargs)

--- a/uplink/converters/interfaces.py
+++ b/uplink/converters/interfaces.py
@@ -20,3 +20,9 @@ class ConverterFactory(object):
     def make_string_converter(self, type_, argument_annotations,
                               method_annotations):
         pass
+
+
+class RequiresChain(object):
+
+    def set_chain(self, chain):
+        raise NotImplementedError

--- a/uplink/converters/interfaces.py
+++ b/uplink/converters/interfaces.py
@@ -3,17 +3,21 @@ class Converter(object):
     def convert(self, value):
         raise NotImplementedError
 
+    def __call__(self, *args, **kwargs):
+        return self.convert(*args, **kwargs)
+
 
 class ConverterFactory(object):
 
     def make_response_body_converter(self, type_, argument_annotations,
                                      method_annotations):
-        raise NotImplementedError
+        pass
 
     def make_request_body_converter(self, type_, argument_annotations,
                                     method_annotations):
-        raise NotImplementedError
+        pass
 
     def make_string_converter(self, type_, argument_annotations,
                               method_annotations):
+        pass
         raise NotImplementedError

--- a/uplink/converters/interfaces.py
+++ b/uplink/converters/interfaces.py
@@ -6,6 +6,9 @@ class Converter(object):
     def __call__(self, *args, **kwargs):
         return self.convert(*args, **kwargs)
 
+    def set_chain(self, chain):
+        pass
+
 
 class ConverterFactory(object):
 
@@ -20,9 +23,3 @@ class ConverterFactory(object):
     def make_string_converter(self, type_, argument_annotations,
                               method_annotations):
         pass
-
-
-class RequiresChain(object):
-
-    def set_chain(self, chain):
-        raise NotImplementedError

--- a/uplink/converters/interfaces.py
+++ b/uplink/converters/interfaces.py
@@ -20,4 +20,3 @@ class ConverterFactory(object):
     def make_string_converter(self, type_, argument_annotations,
                               method_annotations):
         pass
-        raise NotImplementedError

--- a/uplink/converters/keys.py
+++ b/uplink/converters/keys.py
@@ -34,13 +34,6 @@ class CompositeKey(object):
     Arguments:
         converter_key: The enveloped converter key.
     """
-    class ConverterUsingFunction(interfaces.Converter):
-        def __init__(self, convert_function):
-            self._convert = convert_function
-
-        def convert(self, value):
-            return self._convert(value)
-
     def __init__(self, converter_key):
         self._converter_key = converter_key
 
@@ -57,8 +50,7 @@ class CompositeKey(object):
 
         def factory_wrapper(*args, **kwargs):
             converter = factory(*args, **kwargs)
-            convert_func = functools.partial(self.convert, converter)
-            return self.ConverterUsingFunction(convert_func)
+            return functools.partial(self.convert, converter)
 
         return factory_wrapper
 
@@ -74,7 +66,7 @@ class Map(CompositeKey):
         Map(CONVERT_TO_STRING)
     """
     def convert(self, converter, value):
-        return dict((k, converter.convert(value[k])) for k in value)
+        return dict((k, converter(value[k])) for k in value)
 
 
 class Sequence(CompositeKey):
@@ -89,6 +81,6 @@ class Sequence(CompositeKey):
     """
     def convert(self, converter, value):
         if isinstance(value, (list, tuple)):
-            return list(map(converter.convert, value))
+            return list(map(converter, value))
         else:
-            return converter.convert(value)
+            return converter(value)

--- a/uplink/converters/marshmallow_.py
+++ b/uplink/converters/marshmallow_.py
@@ -7,7 +7,7 @@ to deserialize and serialize values.
 import inspect
 
 # Local imports
-from uplink.converters import interfaces
+from uplink.converters import interfaces, register
 
 
 class MarshmallowConverter(interfaces.ConverterFactory):
@@ -39,6 +39,7 @@ class MarshmallowConverter(interfaces.ConverterFactory):
 
             $ pip install uplink[marshmallow]
     """
+
     try:
         import marshmallow
     except ImportError:  # pragma: no cover
@@ -102,5 +103,6 @@ class MarshmallowConverter(interfaces.ConverterFactory):
         """
         return self._make_converter(self.ResponseBodyConverter, type_)
 
-    def make_string_converter(self, type_, *args, **kwargs):
-        return None
+
+if MarshmallowConverter.marshmallow is not None:
+    register.register_converter_factory(MarshmallowConverter)

--- a/uplink/converters/register.py
+++ b/uplink/converters/register.py
@@ -1,0 +1,22 @@
+# Standard library imports
+import collections
+
+# Local imports
+from uplink.converters import interfaces
+
+_default_converter_factories = collections.deque()
+
+
+def register_converter_factory(factory_proxy):
+    factory = factory_proxy() if callable(factory_proxy) else factory_proxy
+    if not isinstance(factory, interfaces.ConverterFactory):
+        raise TypeError(
+            "Failed to register '%s' as converter factory: it is not an "
+            "instance of '%s'." % (factory, interfaces.ConverterFactory)
+        )
+    _default_converter_factories.appendleft(factory)
+    return factory_proxy
+
+
+def get_default_converter_factories():
+    return tuple(_default_converter_factories)

--- a/uplink/converters/standard.py
+++ b/uplink/converters/standard.py
@@ -1,0 +1,50 @@
+# Standard library imports
+import json
+
+# Local imports
+from uplink.converters import interfaces, register
+
+
+class Cast(interfaces.Converter):
+    def __init__(self, caster, converter):
+        self._cast = caster
+        self._converter = converter
+
+    def convert(self, value):
+        if callable(self._cast):
+            value = self._cast(value)
+        return self._converter(value)
+
+
+class RequestBodyConverter(interfaces.Converter):
+    def convert(self, value):
+        if isinstance(value, str):
+            return value
+        else:
+            return json.loads(
+                json.dumps(value, default=lambda obj: obj.__dict__)
+            )
+
+
+class StringConverter(interfaces.Converter):
+    def convert(self, value):
+        return str(value)
+
+
+@register.register_converter_factory
+class StandardConverter(interfaces.ConverterFactory):
+    """
+    The default converter, this class seeks to provide sane alternatives
+    for (de)serialization when all else fails -- e.g., no other
+    converters could handle a particular type.
+    """
+
+    def make_response_body_converter(self, type_, *args, **kwargs):
+        if callable(type_):
+            return type_
+
+    def make_request_body_converter(self, type_, *args, **kwargs):
+        return Cast(type_, RequestBodyConverter())  # pragma: no cover
+
+    def make_string_converter(self, type_, *args, **kwargs):
+        return Cast(type_, StringConverter())  # pragma: no cover

--- a/uplink/converters/typing_.py
+++ b/uplink/converters/typing_.py
@@ -17,7 +17,7 @@ class BaseTypeConverter(object):
         return cls.Builder(functools.partial(cls, *args, **kwargs))
 
 
-class ListConverter(BaseTypeConverter, interfaces.RequiresChain):
+class ListConverter(BaseTypeConverter, interfaces.Converter):
 
     def __init__(self, elem_type):
         self._elem_type = elem_type
@@ -26,14 +26,14 @@ class ListConverter(BaseTypeConverter, interfaces.RequiresChain):
     def set_chain(self, chain):
         self._elem_converter = chain(self._elem_type)
 
-    def __call__(self, value):
+    def convert(self, value):
         if isinstance(value, (list, tuple)):
             return list(map(self._elem_converter, value))
         else:
             return self._elem_converter(value)
 
 
-class DictConverter(BaseTypeConverter, interfaces.RequiresChain):
+class DictConverter(BaseTypeConverter, interfaces.Converter):
 
     def __init__(self, key_type, value_type):
         self._key_type = key_type
@@ -45,7 +45,7 @@ class DictConverter(BaseTypeConverter, interfaces.RequiresChain):
         self._key_converter = chain(self._key_type)
         self._value_converter = chain(self._value_type)
 
-    def __call__(self, value):
+    def convert(self, value):
         if isinstance(value, collections.Mapping):
             key_c, val_c = self._key_converter, self._value_converter
             return dict((key_c(k), val_c(value[k])) for k in value)

--- a/uplink/converters/typing_.py
+++ b/uplink/converters/typing_.py
@@ -1,0 +1,82 @@
+# Standard library imports
+import collections
+import functools
+import inspect
+
+# Local imports
+from uplink.converters import interfaces, register
+
+__all__ = ["TypingConverter", "ListConverter", "DictConverter"]
+
+
+class BaseTypeConverter(object):
+    Builder = collections.namedtuple("Builder", "build")
+
+    @classmethod
+    def freeze(cls, *args, **kwargs):
+        return cls.Builder(functools.partial(cls, *args, **kwargs))
+
+
+class ListConverter(BaseTypeConverter, interfaces.Converter,
+                    interfaces.RequiresChain):
+
+    def __init__(self, elem_type):
+        self._elem_type = elem_type
+        self._elem_converter = None
+
+    def set_chain(self, chain):
+        self._elem_converter = chain(self._elem_type)
+
+    def convert(self, value):
+        if isinstance(value, (list, tuple)):
+            return list(map(self._elem_converter, value))
+        else:
+            return self._elem_converter(value)
+
+
+class DictConverter(BaseTypeConverter, interfaces.Converter,
+                    interfaces.RequiresChain):
+
+    def __init__(self, key_type, value_type):
+        self._key_type = key_type
+        self._value_type = value_type
+        self._key_converter = None
+        self._value_converter = None
+
+    def set_chain(self, chain):
+        self._key_converter = chain(self._key_type)
+        self._value_converter = chain(self._value_type)
+
+    def convert(self, value):
+        if isinstance(value, collections.Mapping):
+            key_c, val_c = self._key_converter, self._value_converter
+            return dict((key_c(k), val_c(value[k])) for k in value)
+        else:
+            return self._value_converter(value)
+
+
+@register.register_converter_factory
+class TypingConverter(interfaces.ConverterFactory):
+    try:
+        import typing
+    except ImportError:
+        typing = None
+
+    @staticmethod
+    def is_subclass(t, ot):
+        return inspect.isclass(t) and issubclass(t, ot)
+
+    def _base_converter(self, type_, *args, **kwargs):
+        if isinstance(type_, BaseTypeConverter.Builder):
+            return type_.build()
+        elif self.typing is not None:
+            if self.is_subclass(type_, self.typing.List):
+                return ListConverter(*type_.__args__)
+            elif self.is_subclass(type_, self.typing.Dict):
+                return DictConverter(*type_.__args__)
+
+    def make_response_body_converter(self, *args, **kwargs):
+        return self._base_converter(*args, **kwargs)
+
+    def make_request_body_converter(self, *args, **kwargs):
+        return self._base_converter(*args, **kwargs)

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -3,7 +3,7 @@ import inspect
 
 # Local imports
 from uplink import exceptions, helpers, hooks, interfaces, types
-
+from uplink.converters import typing_
 
 __all__ = [
     "headers",
@@ -291,6 +291,32 @@ class returns(MethodAnnotation):
 
     def modify_request(self, request_builder):
         request_builder.return_type = self._type
+
+    try:
+        import typing as _typing
+    except ImportError:
+        class _TypeProxy(object):
+            def __init__(self, func):
+                self._func = func
+
+            def __getitem__(self, item):
+                items = item if isinstance(item, tuple) else (item,)
+                return self._func(*items)
+
+        _typing = False
+        List = _TypeProxy(typing_.ListConverter.freeze)
+        Dict = _TypeProxy(typing_.DictConverter.freeze)
+    else:
+        List = _typing.List
+        Dict = _typing.Dict
+
+    @classmethod
+    def list(cls, t):
+        return cls(cls.List[t])
+
+    @classmethod
+    def dict(cls, kt, vt):
+        return cls(cls.Dict[kt, vt])
 
 
 # noinspection PyPep8Naming

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -2,8 +2,7 @@
 import inspect
 
 # Local imports
-from uplink import exceptions, helpers, hooks, interfaces, types
-from uplink.converters import typing_
+from uplink import converters, exceptions, helpers, hooks, interfaces, types
 
 __all__ = [
     "headers",
@@ -292,23 +291,8 @@ class returns(MethodAnnotation):
     def modify_request(self, request_builder):
         request_builder.return_type = self._type
 
-    try:
-        import typing as _typing
-    except ImportError:
-        class _TypeProxy(object):
-            def __init__(self, func):
-                self._func = func
-
-            def __getitem__(self, item):
-                items = item if isinstance(item, tuple) else (item,)
-                return self._func(*items)
-
-        _typing = False
-        List = _TypeProxy(typing_.ListConverter.freeze)
-        Dict = _TypeProxy(typing_.DictConverter.freeze)
-    else:
-        List = _typing.List
-        Dict = _typing.Dict
+    List = converters.TypingConverter.List
+    Dict = converters.TypingConverter.Dict
 
     @classmethod
     def list(cls, t):

--- a/uplink/types.py
+++ b/uplink/types.py
@@ -163,8 +163,7 @@ class ArgumentAnnotation(interfaces.Annotation):
     def modify_request(self, request_builder, value):
         argument_type, converter_key = self.type, self.converter_key
         converter = request_builder.get_converter(converter_key, argument_type)
-        value = converter.convert(value)
-        self._modify_request(request_builder, value)
+        self._modify_request(request_builder, converter(value))
 
 
 class TypedArgument(ArgumentAnnotation):


### PR DESCRIPTION
Requires #77 

If the `typing` module is installed, the following features are enabled:

1. Converts`typing.List[T]` to a list of items of type T:
```python
@get("/users")
def get_users(self) -> List[User]:
    pass
```
2. Converts `typing.Dict[KT, VT]` to a mapping of keys of type KT and values of type VT (similar to above)

To handle type hints in Python 2.7 for responses, users can use the `uplink.returns.list` or `uplink.returns.dict` decorator:
```python
@uplink.returns.list(User)
@get("/users")
def get_users(self):
    pass
```