### PR TITLE
Make it easier to integrate Uplink into existing code that uses type hints

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -120,6 +120,12 @@ class TestArgumentAnnotationHandlerBuilder(object):
         with pytest.raises(types.ExhaustedArguments):
             builder.add_annotation(argument_mock)
 
+    def test_add_annotation_that_is_not_an_annotation(self):
+        def dummy(): pass
+        builder = types.ArgumentAnnotationHandlerBuilder(dummy, ["arg1"], False)
+        builder.add_annotation(type, "arg1")
+        assert builder.remaining_args_count == 1
+
     @inject_args
     def test_set_annotations(self, mocker, argument_mock, args):
         builder = types.ArgumentAnnotationHandlerBuilder(None, args, False)
@@ -186,6 +192,17 @@ class TestTypedArgument(object):
 
     def test_type(self):
         assert types.TypedArgument("hello").type == "hello"
+
+    def test_set_type(self):
+        annotation = types.TypedArgument()
+        assert annotation.type is None
+        annotation.type = "type"
+        assert annotation.type == "type"
+
+    def test_set_type_with_type_already_set(self):
+        annotation = types.TypedArgument("type")
+        with pytest.raises(AttributeError):
+            annotation.type = "new type"
 
 
 class TestNamedArgument(object):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -99,10 +99,10 @@ class TestArgumentAnnotationHandlerBuilder(object):
         assert args[0] not in builder.missing_arguments
 
     @inject_args
-    def test_add_annotation_class(self, mocker, argument_mock, args):
+    def test_add_annotation_class(self, mocker, args):
         builder = types.ArgumentAnnotationHandlerBuilder(None, args, False)
         builder.listener = mocker.stub()
-        argument = builder.add_annotation(type(argument_mock))
+        argument = builder.add_annotation(types.ArgumentAnnotation())
         builder.listener.assert_called_with(argument)
         assert args[0] not in builder.missing_arguments
 

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -52,7 +52,11 @@ class HttpMethod(object):
             arg_handler,
             decorators.MethodAnnotationHandlerBuilder()
         )
-        arg_handler.add_annotations_from_spec(spec)
+
+        # Need to add the annotations after constructing the request
+        # definition builder so it has a chance to attach its listener.
+        arg_handler.set_annotations(spec.annotations)
+
         if spec.return_annotation is not None:
             builder = decorators.returns(spec.return_annotation)(builder)
         functools.update_wrapper(builder, func)

--- a/uplink/types.py
+++ b/uplink/types.py
@@ -84,7 +84,6 @@ class ArgumentAnnotationHandlerBuilder(interfaces.AnnotationHandlerBuilder):
 
     @staticmethod
     def _is_annotation(annotation):
-        print(annotation)
         is_annotation_class = (
                 inspect.isclass(annotation) and
                 issubclass(annotation, interfaces.Annotation)

--- a/uplink/types.py
+++ b/uplink/types.py
@@ -105,15 +105,19 @@ class ArgumentAnnotationHandlerBuilder(interfaces.AnnotationHandlerBuilder):
             raise ExhaustedArguments(annotation, self._func)
         if name not in self._annotations:
             raise ArgumentNotFound(name, self._func)
+        annotation = self._process_annotation(name, annotation)
+        super(ArgumentAnnotationHandlerBuilder, self).add_annotation(annotation)
+        self._defined += self._annotations[name] is None
+        self._annotations[name] = annotation
+        return annotation
+
+    def _process_annotation(self, name, annotation):
         if inspect.isclass(annotation):
             annotation = annotation()
         if isinstance(annotation, TypedArgument) and annotation.type is None:
             annotation.type = self._argument_types.pop(name, None)
         if isinstance(annotation, NamedArgument) and annotation.name is None:
             annotation.name = name
-        super(ArgumentAnnotationHandlerBuilder, self).add_annotation(annotation)
-        self._defined += self._annotations[name] is None
-        self._annotations[name] = annotation
         return annotation
 
     def is_done(self):

--- a/uplink/types.py
+++ b/uplink/types.py
@@ -52,24 +52,19 @@ class ArgumentAnnotationHandlerBuilder(interfaces.AnnotationHandlerBuilder):
             spec = utils.get_arg_spec(func)
             handler = cls(func, spec.args)
             setattr(func, cls.__ANNOTATION_BUILDER_KEY, handler)
-            handler.add_annotations_from_spec(spec)
+            handler.set_annotations(spec.annotations)
         return getattr(func, cls.__ANNOTATION_BUILDER_KEY)
 
     def __init__(self, func, arguments, func_is_method=True):
         self._arguments = arguments[func_is_method:]
-        self._argument_types = collections.OrderedDict.fromkeys(self._arguments)
+        self._annotations = collections.OrderedDict.fromkeys(self._arguments)
         self._defined = 0
         self._func = func
-
-    def add_annotations_from_spec(self, spec):
-        if spec.args:
-            # Ignore `self` instance reference
-            spec.annotations.pop(spec.args[0], None)
-        self.set_annotations(spec.annotations)
+        self._argument_types = {}
 
     @property
     def missing_arguments(self):
-        return (a for a in self._arguments if self._argument_types[a] is None)
+        return (a for a in self._arguments if self._annotations[a] is None)
 
     @property
     def remaining_args_count(self):
@@ -87,20 +82,39 @@ class ArgumentAnnotationHandlerBuilder(interfaces.AnnotationHandlerBuilder):
         for name in more_annotations:
             self.add_annotation(more_annotations[name], name)
 
+    @staticmethod
+    def _is_annotation(annotation):
+        print(annotation)
+        is_annotation_class = (
+                inspect.isclass(annotation) and
+                issubclass(annotation, interfaces.Annotation)
+        )
+        return (
+            is_annotation_class or isinstance(annotation, interfaces.Annotation)
+        )
+
     def add_annotation(self, annotation, name=None, *args, **kwargs):
+        if self._is_annotation(annotation):
+            return self._add_annotation(annotation, name)
+        else:
+            self._argument_types[name] = annotation
+
+    def _add_annotation(self, annotation, name=None):
         try:
             name = next(self.missing_arguments) if name is None else name
         except StopIteration:
             raise ExhaustedArguments(annotation, self._func)
-        if name not in self._argument_types:
+        if name not in self._annotations:
             raise ArgumentNotFound(name, self._func)
         if inspect.isclass(annotation):
             annotation = annotation()
+        if isinstance(annotation, TypedArgument) and annotation.type is None:
+            annotation.type = self._argument_types.pop(name, None)
         if isinstance(annotation, NamedArgument) and annotation.name is None:
             annotation.name = name
         super(ArgumentAnnotationHandlerBuilder, self).add_annotation(annotation)
-        self._defined += self._argument_types[name] is None
-        self._argument_types[name] = annotation
+        self._defined += self._annotations[name] is None
+        self._annotations[name] = annotation
         return annotation
 
     def is_done(self):
@@ -108,7 +122,7 @@ class ArgumentAnnotationHandlerBuilder(interfaces.AnnotationHandlerBuilder):
 
     @property
     def _types(self):
-        types = self._argument_types
+        types = self._annotations
         return ((k, types[k]) for k in types if types[k] is not None)
 
     def build(self):
@@ -175,6 +189,13 @@ class TypedArgument(ArgumentAnnotation):
     @property
     def type(self):
         return self._type
+
+    @type.setter
+    def type(self, type_):
+        if self._type is None:
+            self._type = type_
+        else:
+            raise AttributeError("Type is already set.")
 
     @property
     def converter_key(self):  # pragma: no cover
@@ -564,7 +585,7 @@ class PartMap(TypedArgument):
         return keys.Map(keys.CONVERT_TO_REQUEST_BODY)
 
     def _modify_request(self, request_builder, value):
-        """Updaytes request body to with the form parts."""
+        """Updates request body to with the form parts."""
         request_builder.info["files"].update(value)
 
 


### PR DESCRIPTION
Existing clients that may be using type hints in their function annotations might opt to use the `uplink.args` decorator instead of replacing their existing function annotations with fields like `uplink.Path` or `uplink.Query`. For instance:

```python
@uplink.args(uplink.Path("id"))
@uplink.get("/users/{id}")
def get_user(self, user_id: str):
   pass
```

For such use cases, these changes will ensure that the argument (i.e., `user_id` in the above example) retains the type of it's corresponding argument (i.e., `str`). This can be useful, since -- for example -- uplink's converter layer will then try to convert any value passed into `user_id` argument into a `str`. This differs from the existing behavior, as the converter layer would not have handled the value conversion at all since `uplink.Path` is not specified with any type.

In other words, with these changes, the above code is equivalent to:
```python
@uplink.args(uplink.Path("id", type=str))
@uplink.get("/users/{id}")
def get_user(self, user_id: str):
   pass
```

