### PR TITLE
 Don't apply body decorators (e.g., `uplink.json`) to GET methods when used as class decorator

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -115,26 +115,22 @@ class TestMethodAnnotation(object):
         builder = request_definition_builder.method_handler_builder
         builder.add_annotation.assert_called_with(mocker.ANY)
 
-    def test_method_in_http_method_whitelist(self,
+    def test_method_in_http_method_blacklist(self,
                                              method_annotation,
                                              request_definition_builder):
         request_definition_builder.method = "GET"
-        method_annotation.http_method_whitelist = ["GET"]
-        method_annotation.modify_request_definition(
+        method_annotation._http_method_blacklist = ["GET"]
+        assert not method_annotation._is_relevant_for(
             request_definition_builder
         )
-        assert True
 
-    def test_method_not_in_http_method_whitelist(self,
+    def test_method_not_in_http_method_blacklist(self,
                                                  method_annotation,
                                                  request_definition_builder):
         request_definition_builder.method = "POST"
         request_definition_builder.__name__ = "dummy"
-        method_annotation.http_method_whitelist = ["GET"]
-        with pytest.raises(decorators.HttpMethodNotSupport):
-            method_annotation.modify_request_definition(
-                request_definition_builder
-            )
+        method_annotation._http_method_blacklist = ["GET"]
+        assert method_annotation._is_relevant_for(request_definition_builder)
 
     def test_call_with_child_class(self,
                                    method_annotation,

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -106,14 +106,15 @@ class TestMethodAnnotation(object):
                                request_definition_builder):
         method_annotation(request_definition_builder)
         builder = request_definition_builder.method_handler_builder
-        builder.add_annotation.assert_called_with(method_annotation)
+        builder.add_annotation.assert_called_with(
+            method_annotation, is_class=False)
 
     def test_static_call_with_builder(self,
                                       mocker,
                                       request_definition_builder):
         self.FakeMethodAnnotation(request_definition_builder)
         builder = request_definition_builder.method_handler_builder
-        builder.add_annotation.assert_called_with(mocker.ANY)
+        builder.add_annotation.assert_called_with(mocker.ANY, is_class=False)
 
     def test_method_in_http_method_blacklist(self, request_definition_builder):
         class DummyAnnotation(decorators.MethodAnnotation):
@@ -261,7 +262,7 @@ def test_args_call_old(request_definition_builder):
     annotation = decorators.args(str, str, name=str)
     annotation(request_definition_builder)
     handler = request_definition_builder.method_handler_builder
-    handler.add_annotation.assert_called_with(annotation)
+    handler.add_annotation.assert_called_with(annotation, is_class=False)
 
 
 def test_response_handler(request_builder):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -5,7 +5,7 @@ import collections
 import pytest
 
 # Local imports
-from uplink import decorators
+from uplink import decorators, interfaces
 
 
 @pytest.fixture
@@ -83,7 +83,7 @@ class TestMethodAnnotation(object):
     def test_call_with_class(self,
                              method_annotation,
                              request_definition_builder):
-        class Class(object):
+        class Class(interfaces.Consumer):
             builder = request_definition_builder
 
         method_annotation(Class)
@@ -94,7 +94,7 @@ class TestMethodAnnotation(object):
     def test_static_call_with_class(
             self, mocker, request_definition_builder
     ):
-        class Class(object):
+        class Class(interfaces.Consumer):
             builder = request_definition_builder
 
         self.FakeMethodAnnotation(Class)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -115,22 +115,25 @@ class TestMethodAnnotation(object):
         builder = request_definition_builder.method_handler_builder
         builder.add_annotation.assert_called_with(mocker.ANY)
 
-    def test_method_in_http_method_blacklist(self,
-                                             method_annotation,
-                                             request_definition_builder):
+    def test_method_in_http_method_blacklist(self, request_definition_builder):
+        class DummyAnnotation(decorators.MethodAnnotation):
+            _http_method_blacklist = ["GET"]
+
         request_definition_builder.method = "GET"
-        method_annotation._http_method_blacklist = ["GET"]
-        assert not method_annotation._is_relevant_for(
-            request_definition_builder
+        assert not DummyAnnotation.supports_http_method(
+            request_definition_builder.method
         )
 
-    def test_method_not_in_http_method_blacklist(self,
-                                                 method_annotation,
+    def test_method_not_in_http_method_blacklist(self, 
                                                  request_definition_builder):
+        class DummyAnnotation(decorators.MethodAnnotation):
+            _http_method_whitelist = ["POST"]
+
         request_definition_builder.method = "POST"
         request_definition_builder.__name__ = "dummy"
-        method_annotation._http_method_blacklist = ["GET"]
-        assert method_annotation._is_relevant_for(request_definition_builder)
+        assert DummyAnnotation().supports_http_method(
+            request_definition_builder.method
+        )
 
     def test_call_with_child_class(self,
                                    method_annotation,

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -218,7 +218,7 @@ class ConsumerMeta(type):
 _Consumer = ConsumerMeta("_Consumer", (), {})
 
 
-class Consumer(_Consumer):
+class Consumer(interfaces.Consumer, _Consumer):
 
     def __init__(
             self,

--- a/uplink/interfaces.py
+++ b/uplink/interfaces.py
@@ -141,3 +141,6 @@ class Auth(object):
 
     def __call__(self, request_builder):
         raise NotImplementedError
+
+class Consumer(object):
+    pass


### PR DESCRIPTION
Method annotations like `uplink.json` can be used as a class decorator, in which case the annotation is applied to all consumer methods defined on the class. 

This PR introduces a blacklist/whitelist mechanism that annotation writers can use to limit which consumer methods the annotation is applied to when used as a class decorator.