### PR TITLE
Add `returns.json` decorator

### DIFF
--- a/docs/source/converters.rst
+++ b/docs/source/converters.rst
@@ -29,8 +29,8 @@ Uplink comes with optional support for :py:mod:`marshmallow`.
     to provide it when constructing your consumer instances.
 
 
-Collections
-===========
+Type Hints
+==========
 
 .. versionadded:: v0.5.0
 
@@ -48,7 +48,6 @@ instance:
 .. autoclass:: uplink.converters.TypingConverter
 
 ..
-
     Writing a Custom Converter
     ==========================
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -225,13 +225,22 @@ def test_returns(request_builder):
     returns.modify_request(request_builder)
     assert request_builder.return_type is str
 
-    returns = decorators.returns.list(str)
-    returns.modify_request(request_builder)
-    assert request_builder.return_type == returns.List[str]
 
-    returns = decorators.returns.dict(str, str)
-    returns.modify_request(request_builder)
-    assert request_builder.return_type == returns.Dict[str, str]
+def test_returns_json(request_builder):
+    returns_json = decorators.returns.json(str, ())
+    returns_json.modify_request(request_builder)
+    assert isinstance(request_builder.return_type, decorators.returns.Json)
+
+
+def test_returns_Json(mocker):
+    response = mocker.Mock(spec=["json"])
+    response.json.return_value = {"hello": "world"}
+    converter = decorators.returns.Json(str, "hello")
+    converter.set_chain(lambda x: None)
+    assert converter.convert(response) == "world"
+
+    converter.set_chain(lambda x: (lambda y: y + "!"))
+    assert converter.convert(response) == "world!"
 
 
 def test_args(request_definition_builder):

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -14,7 +14,7 @@ class MissingArgumentAnnotations(exceptions.InvalidRequestDefinition):
     def __init__(self, missing, path_variables):
         missing, path_variables = list(missing), list(path_variables)
         self.message = self.message % "', '".join(missing)
-        if path_variables:
+        if path_variables:  # pragma: no cover
             self.message += self.implicit_message % "', '".join(path_variables)
 
 

--- a/uplink/converters/typing_.py
+++ b/uplink/converters/typing_.py
@@ -75,6 +75,8 @@ def _get_types(try_typing=True):
 @register.register_default_converter_factory
 class TypingConverter(interfaces.ConverterFactory):
     """
+    .. versionadded: v0.5.0
+
     An adapter that serializes and deserializes collection types from
     the :py:mod:`typing` module, such as :py:class:`typing.List`.
 

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -420,7 +420,7 @@ class returns(MethodAnnotation):
                 :emphasize-lines: 2
 
                 {
-                    "data": { "user": "prkumar", "id": 10432 }
+                    "data": { "user": "prkumar", "id": 140232 },
                     "errors": []
                 }
 

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -335,31 +335,35 @@ class returns(MethodAnnotation):
     def modify_request(self, request_builder):
         request_builder.return_type = self._type
 
+    List = converters.TypingConverter.List
     """
+    .. versionadded:: v0.5.0
+    
     A proxy for :py:class:`typing.List` that is safe to use in type 
     hints with Python 3.4 and below.
-    
+
     .. code-block:: python
-        
+
         @returns.json
         @get("/users")
         def get_users(self) -> returns.List[str]:
             \"""Fetches all users\"""
     """
-    List = converters.TypingConverter.List
 
+    Dict = converters.TypingConverter.Dict
     """
+    .. versionadded:: v0.5.0
+    
     A proxy for :py:class:`typing.Dict` that is safe to use in type 
     hints with Python 3.4 and below
-    
+
     .. code-block:: python
-        
+
         @returns.json
         @get("/users")
         def get_users(self) -> returns.Dict[str, str]:
             \"""Fetches all users\"""
     """
-    Dict = converters.TypingConverter.Dict
 
     class Json(converters.interfaces.Converter):
         # TODO: Support JSON Pointer (https://tools.ietf.org/html/rfc6901)
@@ -385,6 +389,83 @@ class returns(MethodAnnotation):
 
     # noinspection PyPep8Naming
     class json(MethodAnnotation):
+        """
+        .. versionadded:: v0.5.0
+
+        Specifies that the decorated consumer method should return a
+        JSON object.
+
+        Example:
+
+            .. code-block:: python
+
+                @returns.json
+                @get("/users/{username}")
+                def get_user(self, username):
+                    \"""Get a specific user.\"""
+
+
+        Returning a Specific JSON Field:
+
+            This decorator accepts two optional arguments. The
+            :py:attr:`member` argument accepts a string or tuple that
+            specifies the path of an internal field in the JSON
+            document.
+
+            For instance, consider an API that returns JSON responses
+            that, at the root of the document, contains both the
+            server-retrieved data and a list of relevant API errors:
+
+            .. code-block:: json
+                :emphasize-lines: 2
+
+                {
+                    "data": { "user": "prkumar", "id": 10432 }
+                    "errors": []
+                }
+
+            If returning the list of errors is unnecessary, we can use
+            the :py:attr:`member` argument to strictly return the inner
+            field :py:attr:`data`:
+
+            .. code-block:: python
+
+                @returns.json(member="data")
+                @get("/users/{username}")
+                def get_user(self, username):
+                    \"""Get a specific user.\"""
+
+        Deserialize Objects from JSON:
+
+            Often, JSON responses represent models in your application.
+            If an existing Python object encapsulates this model, use
+            the :py:attr:`model` argument to specify it as the return
+            type:
+
+            .. code-block:: python
+
+                @returns.json(model=User, member="data")
+                @get("/users/{username}")
+                def get_user(self, username):
+                    \"""Get a specific user.\"""
+
+            This pattern typically requires also registering a converter
+            that knows how to deserialize the JSON into your data model
+            object or leveraging a built-in converter (e.g.,
+            :py:class:`uplink.converters.MarshmallowConverter`).
+
+            For Python 3 users, you can alternatively provide a return
+            value annotation. Hence, the previous code is equivalent
+            to the following in Python 3:
+
+            .. code-block:: python
+
+                @returns.json(member="data")
+                @get("/users/{username}")
+                def get_user(self, username) -> User:
+                    \"""Get a specific user.\"""
+
+        """
         _can_be_static = True
 
         def __init__(self, model=None, member=()):

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -67,6 +67,7 @@ class MethodAnnotationHandler(interfaces.AnnotationHandler):
             annotation.modify_request(request_builder)
 
 
+# TODO: Only decorate consumers
 class MethodAnnotation(interfaces.Annotation):
     http_method_whitelist = None
 
@@ -360,20 +361,6 @@ class returns(MethodAnnotation):
     """
     Dict = converters.TypingConverter.Dict
 
-    @classmethod
-    def list(cls, t):
-        """
-        TODO: Remove this
-        """
-        return cls(cls.List[t])
-
-    @classmethod
-    def dict(cls, kt, vt):
-        """
-        TODO: Remove this
-        """
-        return cls(cls.Dict[kt, vt])
-
     class Json(converters.interfaces.Converter):
         # TODO: Support JSON Pointer (https://tools.ietf.org/html/rfc6901)
 
@@ -396,6 +383,7 @@ class returns(MethodAnnotation):
                 content = self._model_converter(content)
             return content
 
+    # noinspection PyPep8Naming
     class json(MethodAnnotation):
         _can_be_static = True
 


### PR DESCRIPTION
Specifies that the decorated consumer method should return a JSON object.

Example
--------
```python
@returns.json
@get("/users/{username}")
    def get_user(self, username):
        """Get a specific user."""
```

Returning a Specific JSON Field
=======================

This decorator accepts two optional arguments. The `member` argument accepts a string or tuple that specifies the path of an internal field in the JSON document.

For instance, consider an API that returns JSON responses that, at the root of the document, contains both the server-retrieved data and a list of relevant API errors:

```json
{
    "data": { "user": "prkumar", "id": 10432 },
     "errors": []
}
```

If returning the list of errors is unnecessary, we can use the `member` argument to strictly return the inner field `data`:

```python
@returns.json(member="data")
@get("/users/{username}")
def get_user(self, username):
    """Get a specific user."""
```

Deserialize Objects from JSON
======================
Often, JSON responses represent models in your application. If an existing Python object encapsulates this model, use the `model` argument to specify it as the return type:

```python
@returns.json(model=User, member="data")
@get("/users/{username}")
def get_user(self, username):
    """Get a specific user."""
```

This pattern typically requires also registering a converter that knows how to deserialize the JSON into your data model object or leveraging a built-in converter (e.g. `uplink.converters.MarshmallowConverter`).

For Python 3 users, you can alternatively provide a return value annotation. Hence, the previous code is equivalent to the following in Python 3:

```python
@returns.json(member="data")
@get("/users/{username}")
def get_user(self, username) -> User:
    """Get a specific user."""
```