### PR TITLE
Release Hotfix v0.5.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,18 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to the
 `Semantic Versioning`_ scheme.
 
+0.5.1_ - 2018-4-10
+==================
+Added
+-----
+- Decorator ``uplink.returns.model`` for specifying custom return type without
+  indicating a specific data deserialization format.
+
+Fixed
+-----
+- Have ``uplink.Body`` decorator accept any type, not just mappings.
+- Reintroduce the ``uplink.returns`` decorator.
+
 0.5.0_ - 2018-4-06
 ==================
 Added
@@ -142,6 +154,7 @@ Added
 .. _`Semantic Versioning`: https://packaging.python.org/tutorials/distributing-packages/#semantic-versioning-preferred
 
 .. Releases
+.. _0.5.1: https://github.com/prkumar/uplink/compare/v0.5.0...v0.5.1
 .. _0.5.0: https://github.com/prkumar/uplink/compare/v0.4.1...v0.5.0
 .. _0.4.1: https://github.com/prkumar/uplink/compare/v0.4.0...v0.4.1
 .. _0.4.0: https://github.com/prkumar/uplink/compare/v0.3.0...v0.4.0

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -363,8 +363,14 @@ class TestBody(ArgumentTestCase):
     expected_converter_key = keys.CONVERT_TO_REQUEST_BODY
 
     def test_modify_request(self, request_builder):
+        # Verify with dict
         arguments.Body().modify_request(request_builder, {"hello": "world"})
         assert request_builder.info["data"] == {"hello": "world"}
+
+        # Verify with non-mapping
+        body = object()
+        arguments.Body().modify_request(request_builder, body)
+        assert request_builder.info["data"] is body
 
 
 class TestUrl(ArgumentTestCase):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -52,7 +52,7 @@ class TestHttpMethod(object):
             return_annotation="return_annotation"
         )
         mocker.patch("uplink.utils.get_arg_spec").return_value = sig
-        returns = mocker.patch("uplink.returns.json")
+        returns = mocker.patch("uplink.returns.custom")
         http_method = commands.HttpMethod("METHOD", uri="/{hello}")
         http_method(func)
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -52,7 +52,7 @@ class TestHttpMethod(object):
             return_annotation="return_annotation"
         )
         mocker.patch("uplink.utils.get_arg_spec").return_value = sig
-        returns = mocker.patch("uplink.returns.custom")
+        returns = mocker.patch("uplink.returns.model")
         http_method = commands.HttpMethod("METHOD", uri="/{hello}")
         http_method(func)
 

--- a/tests/test_returns.py
+++ b/tests/test_returns.py
@@ -2,6 +2,13 @@
 from uplink import returns
 
 
+def test_returns(request_builder):
+    request_builder.get_converter.return_value = str
+    custom = returns(str)
+    custom.modify_request(request_builder)
+    assert request_builder.return_type.unwrap() is str
+
+
 def test_returns_json(request_builder):
     request_builder.get_converter.return_value = str
     returns_json = returns.json(str, ())

--- a/uplink/__about__.py
+++ b/uplink/__about__.py
@@ -3,4 +3,4 @@ This module is the single source of truth for any package metadata
 that is used both in distribution (i.e., setup.py) and within the
 codebase.
 """
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/uplink/arguments.py
+++ b/uplink/arguments.py
@@ -609,8 +609,7 @@ class Body(TypedArgument):
 
     def _modify_request(self, request_builder, value):
         """Updates request body data."""
-        # TODO: Ensure that the body provides a mapping interface.
-        request_builder.info.setdefault("data", {}).update(value)
+        request_builder.info["data"] = value
 
 
 class Url(ArgumentAnnotation):

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -70,7 +70,7 @@ class HttpMethod(object):
 
         # Use return value type hint as expected return type
         if spec.return_annotation is not None:
-            builder = returns.json(spec.return_annotation)(builder)
+            builder = returns.custom(spec.return_annotation)(builder)
         functools.update_wrapper(builder, func)
         builder = self._add_args(builder)
         return builder

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -70,7 +70,7 @@ class HttpMethod(object):
 
         # Use return value type hint as expected return type
         if spec.return_annotation is not None:
-            builder = returns.custom(spec.return_annotation)(builder)
+            builder = returns.model(spec.return_annotation)(builder)
         functools.update_wrapper(builder, func)
         builder = self._add_args(builder)
         return builder

--- a/uplink/returns.py
+++ b/uplink/returns.py
@@ -185,6 +185,8 @@ class model(_ReturnsBase):
     To have Uplink convert response bodies into the desired type, you
     will need to define an appropriate converter (e.g., using
     :py:class:`uplink.loads`).
+
+    .. versionadded:: v0.5.1
     """
 
     def __init__(self, type):

--- a/uplink/returns.py
+++ b/uplink/returns.py
@@ -166,13 +166,17 @@ class model(_ReturnsBase):
 
     In Python 3, to provide a consumer method's return type, you can
     set it as the method's return annotation:
+
     .. code-block:: python
+
         @get("/users/{username}")
         def get_user(self, username) -> UserSchema:
             \"""Get a specific user.\"""
 
     For Python 2.7 compatibility, you can use this decorator instead:
+
     .. code-block:: python
+
         @returns.model(UserSchema)
         @get("/users/{username}")
         def get_user(self, username):

--- a/uplink/returns.py
+++ b/uplink/returns.py
@@ -1,8 +1,11 @@
+# Standard library imports
+import sys
+
 # Local imports
 from uplink import decorators
 from uplink.converters import keys
 
-__all__ = ["json", "from_json"]
+__all__ = ["json", "from_json", "custom"]
 
 
 class _ReturnsBase(decorators.MethodAnnotation):
@@ -156,4 +159,30 @@ class json(_ReturnsBase):
         return JsonStrategy(converter, self._member)
 
 
+# noinspection PyPep8Naming
+class custom(_ReturnsBase):
+
+    def __init__(self, type):
+        self._type = type
+
+    def _get_return_type(self, return_type):
+        return self._type if return_type is None else return_type
+
+    def _make_strategy(self, converter):
+        return converter
+
+
 from_json = json
+
+
+class _ModuleObject(object):
+    old_module = sys.modules[__name__]
+
+    def __getattr__(self, item):
+        return getattr(self.old_module, item)
+
+    def __call__(self, *args, **kwargs):
+        return custom(*args, **kwargs)
+
+
+sys.modules[__name__] = _ModuleObject()


### PR DESCRIPTION
Relates to #89 

# Added
- Decorator ``uplink.returns.model`` for specifying custom return type without
  indicating a specific data deserialization format.

# Fixed
- Have ``uplink.Body`` decorator accept any type, not just mappings.
- Reintroduce the ``uplink.returns`` decorator.
