### PR TITLE
Fix usage of returns.json without arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - '3.6'
 before_script:
   - pip install tox
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install wheel==0.29.0; fi
 script:
   - tox -e py
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ python:
 before_script:
   - |
     if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then
-      # tox 3.0.0 dropped python 3.3.* support.
-      pip install tox==2.9.1
+      # virtualenv 16.0.0 bundles wheel 0.31.1, which drops python 3.3.* support
+      # tox 3.0.0 drops python 3.3.* support
+      pip install virtualenv==15.2.0 tox==2.9.1
     else
       pip install tox
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,13 @@ python:
   - '3.5'
   - '3.6'
 before_script:
-  - pip install tox
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install wheel==0.29.0; fi
+  - |
+    if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then
+      # tox 3.0.0 dropped python 3.3.* support.
+      pip install tox <= 2.9.1
+    else
+      pip install tox
+    fi
 script:
   - tox -e py
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - |
     if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then
       # tox 3.0.0 dropped python 3.3.* support.
-      pip install tox <= 2.9.1
+      pip install tox==2.9.1
     else
       pip install tox
     fi

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to the
 `Semantic Versioning`_ scheme.
 
+0.5.2_ - 2018-5-30
+==================
+Fixed
+-----
+- Applying ``returns.json`` decorator without arguments should produce JSON
+  responses when the decorated method is lacking a return value annotation.
+
 0.5.1_ - 2018-4-10
 ==================
 Added
@@ -154,6 +161,7 @@ Added
 .. _`Semantic Versioning`: https://packaging.python.org/tutorials/distributing-packages/#semantic-versioning-preferred
 
 .. Releases
+.. _0.5.2: https://github.com/prkumar/uplink/compare/v0.5.1...v0.5.2
 .. _0.5.1: https://github.com/prkumar/uplink/compare/v0.5.0...v0.5.1
 .. _0.5.0: https://github.com/prkumar/uplink/compare/v0.4.1...v0.5.0
 .. _0.4.1: https://github.com/prkumar/uplink/compare/v0.4.0...v0.4.1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,9 +1,10 @@
 # Third party imports
 import pytest
+import requests
 
 # Local imports.
 import uplink
-from uplink import utils
+from uplink import utils, clients
 
 # Constants
 BASE_URL = "https://api.github.com/"
@@ -20,6 +21,10 @@ class GitHubService(uplink.Consumer):
     @uplink.timeout(15)
     @uplink.get("/users/{user}/repos")
     def list_repos(self, user): pass
+
+    @uplink.returns.json
+    @uplink.get("/users/{user}/repos/{repo}")
+    def get_repo(self, user, repo): pass
 
 
 @pytest.fixture
@@ -42,3 +47,39 @@ def test_list_repo(github_service_and_client):
         }
     )
 
+
+class RequestMock(clients.interfaces.Request):
+
+    def __init__(self, response):
+        self._response = response
+        self._callback = None
+
+    def send(self, method, url, extras):
+        if self._callback is not None:
+            return self._callback(self._response)
+        else:
+            return self._response
+
+    def add_callback(self, callback):
+        self._callback = callback
+
+    def add_exception_handler(self, exception_handler):
+        pass
+
+
+def test_get_repo(github_service_and_client, mocker):
+    """
+    This integration test ensures that the returns.json returns the
+    Json body when a model is not provided.
+    """
+    # Setup: return a mock response
+    service, http_client = github_service_and_client
+    response = mocker.Mock(spec=requests.Response)
+    expected_body = response.json.return_value = {"key": "value"}
+    http_client.create_request.return_value = RequestMock(response)
+
+    # Run
+    result = service.get_repo("prkumar", "uplink")
+
+    # Verify
+    assert expected_body == result

--- a/uplink/__about__.py
+++ b/uplink/__about__.py
@@ -3,4 +3,4 @@ This module is the single source of truth for any package metadata
 that is used both in distribution (i.e., setup.py) and within the
 codebase.
 """
-__version__ = "0.5.1"
+__version__ = "0.5.2"


### PR DESCRIPTION
This issue was initially reported on [gitter](https://gitter.im/python-uplink/Lobby?at=5b0eca34ba1a351a68d794e2) by @liiight.

Applying ``returns.json`` decorator without arguments should produce JSON
responses when the decorated method is lacking a return value annotation. 

Here's an example to reproduce the issue on v0.5.1:

```python
from uplink import Consumer, returns, get

class GitHub(Consumer):

    @returns.json
    @get("/users/{user}/repos")
    def get_repos(self, user):
        pass


github = GitHub("https://api.github.com")

# This should return the json output, not a Response object:
github.get_repos("prkumar")
```