### PR TITLE
Release Hotfix v0.5.3

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Contributors
 - Brandon Milton (`@brandonio21 <https://github.com/brandonio21>`_)
 - Fabio Rosado (`@fabiorosado <https://github.com/fabiorosado>`_)
 - Niko Eckerskorn (`@kadrach <https://github.com/kadrach>`_)
+- Or Carmi (`@liiight <https://github.com/liiight>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to the
 `Semantic Versioning`_ scheme.
 
+0.5.3_ - 2018-5-31
+==================
+Fixed
+-----
+- Issue where adding two or more response handlers (i.e., functions decorated
+  with ``uplink.response_handler``) to a method caused a ``TypeError`.
+
 0.5.2_ - 2018-5-30
 ==================
 Fixed
@@ -161,6 +168,7 @@ Added
 .. _`Semantic Versioning`: https://packaging.python.org/tutorials/distributing-packages/#semantic-versioning-preferred
 
 .. Releases
+.. _0.5.3: https://github.com/prkumar/uplink/compare/v0.5.2...v0.5.3
 .. _0.5.2: https://github.com/prkumar/uplink/compare/v0.5.1...v0.5.2
 .. _0.5.1: https://github.com/prkumar/uplink/compare/v0.5.0...v0.5.1
 .. _0.5.0: https://github.com/prkumar/uplink/compare/v0.4.1...v0.5.0

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -42,11 +42,19 @@ class TestTransactionHookChain(object):
         chain.handle_response({})
         transaction_hook_mock.handle_response.assert_called_with({})
 
-    def test_delegate_handle_response_multiple(self, transaction_hook_mock):
+    def test_delegate_handle_response_multiple(self, mocker):
+        # Include one hook that can't handle responses
+        mock_response_handler = mocker.stub()
+        mock_request_auditor = mocker.stub()
+
         chain = hooks.TransactionHookChain(
-            transaction_hook_mock, transaction_hook_mock)
+            hooks.RequestAuditor(mock_request_auditor),
+            hooks.ResponseHandler(mock_response_handler),
+            hooks.ResponseHandler(mock_response_handler)
+        )
         chain.handle_response({})
-        transaction_hook_mock.call_count == 2
+        mock_response_handler.call_count == 2
+        mock_request_auditor.call_count == 1
 
     def test_delegate_handle_exception(self, transaction_hook_mock):
         chain = hooks.TransactionHookChain(transaction_hook_mock)

--- a/uplink/__about__.py
+++ b/uplink/__about__.py
@@ -3,4 +3,4 @@ This module is the single source of truth for any package metadata
 that is used both in distribution (i.e., setup.py) and within the
 codebase.
 """
-__version__ = "0.5.2"
+__version__ = "0.5.3"

--- a/uplink/hooks.py
+++ b/uplink/hooks.py
@@ -55,6 +55,7 @@ class TransactionHookChain(TransactionHook):
 
     def __init__(self, *hooks):
         self._hooks = hooks
+        self._response_handlers = []
 
         # TODO: If more than one callback exists on the chain, the chain
         # expects it can execute each synchronously. Instead, we should
@@ -76,15 +77,15 @@ class TransactionHookChain(TransactionHook):
         elif len(response_handlers) == 1:
             self.handle_response = response_handlers[0].handle_response
 
+        self._response_handlers = response_handlers
+
     def audit_request(self, *args, **kwargs):
         for hook in self._hooks:
             hook.audit_request(*args, **kwargs)
 
     def handle_response(self, response, *args, **kwargs):
-        for hook in self._hooks:
-            if hook.handle_response is not None:
-                # This hook can handle responses:
-                response = hook.handle_response(response, *args, **kwargs)
+        for hook in self._response_handlers:
+            response = hook.handle_response(response, *args, **kwargs)
         return response
 
     def handle_exception(self, *args, **kwargs):


### PR DESCRIPTION
Fixed
-----
- Issue where adding two or more response handlers (i.e., functions decorated
  with ``uplink.response_handler``) to a method caused a ``TypeError`.