### PR TITLE
Add `params` decorator

### DIFF
--- a/docs/source/decorators.rst
+++ b/docs/source/decorators.rst
@@ -9,6 +9,12 @@ headers
 
 .. autoclass:: uplink.headers
 
+
+params
+======
+
+.. autoclass:: uplink.params
+
 json
 ====
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -55,19 +55,30 @@ or use the :py:class:`~uplink.Path` annotation.
     @get("group/{id}/users")
     def group_list(self, group_id: Path("id")): pass
 
-:py:class:`~uplink.Query` parameters can also be added.
+:py:class:`~uplink.Query` parameters can also be added dynamically
+by method arguments.
 
 .. code:: python
 
     @get("group/{id}/users")
     def group_list(self, group_id: Path("id"), sort: Query): pass
 
-For complex query parameter combinations, a mapping can be used:
+For complex query parameter combinations, a :py:class:`~uplink.QueryMap`
+can be used:
 
 .. code:: python
 
     @get("group/{id}/users")
-    def group_list(self, group_id: Path("id"), options: QueryMap): pass
+    def group_list(self, group_id: Path("id"), **options: QueryMap): pass
+
+You can set static query parameters for a method using the
+:py:class:`~uplink.params` decorator.
+
+.. code:: python
+
+    @params({"client_id": "my-client", "client_secret": "****"})
+    @get("users/{username}")
+    def get_user(self, username): pass
 
 
 Request Body

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,6 +1,5 @@
 # Standard library imports
 import collections
-
 # Third party imports
 import pytest
 
@@ -166,6 +165,30 @@ def test_headers(request_builder):
     headers_lst.modify_request(request_builder)
     header = {"key_1": "value_1", "key_2": "value_2"}
     assert request_builder.info["headers"] == header
+
+
+def test_params(request_builder):
+    params = decorators.params({"param": "value"})
+    params.modify_request(request_builder)
+    assert request_builder.info["params"] == {"param": "value"}
+
+
+def test_params_with_string(request_builder):
+    params_with_str = decorators.params("param1=value1&param2=value2")
+    params_with_str.modify_request(request_builder)
+    assert request_builder.info["params"] == {
+        "param1": "value1",
+        "param2": "value2"
+    }
+
+
+def test_params_with_list(request_builder):
+    params_list = decorators.params(["param1=value1", "param2=value2"])
+    params_list.modify_request(request_builder)
+    assert request_builder.info["params"] == {
+        "param1": "value1",
+        "param2": "value2"
+    }
 
 
 def test_form_url_encoded(request_builder):

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -157,10 +157,6 @@ class headers(_BaseRequestProperties):
 # noinspection PyPep8Naming
 class params(MethodAnnotation):
     """
-    # TODO: Update tutorial to illustrate that there you can use
-    # this class to set static query parameters, much like the
-    # the difference between Header and headers.
-
     A decorator that adds static query parameters for API calls.
 
     .. code-block:: python

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -8,6 +8,7 @@ from uplink import arguments, helpers, hooks, interfaces, utils
 
 __all__ = [
     "headers",
+    "params",
     "form_url_encoded",
     "multipart",
     "json",

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -102,14 +102,34 @@ class MethodAnnotation(interfaces.Annotation):
         pass
 
 
+class _BaseRequestProperties(MethodAnnotation):
+    def __init__(self, __prop_name, arg, **kwargs):
+        self._name = __prop_name
+        if isinstance(arg, str):
+            key, value = self._split(arg)
+            self._values = {key: value}
+        elif isinstance(arg, list):
+            self._values = dict(self._split(a) for a in arg)
+        else:
+            self._values = dict(arg, **kwargs)
+
+    @staticmethod
+    def _split(arg):
+        return map(str.strip, arg.split(":"))
+
+    def modify_request(self, request_builder):
+        """Updates header contents."""
+        request_builder.info[self._name].update(self._values)
+
+
 # noinspection PyPep8Naming
-class headers(MethodAnnotation):
+class headers(_BaseRequestProperties):
     """
     A decorator that adds static headers for API calls.
 
     .. code-block:: python
 
-        @headers({"User-Agent": "Uplink-Sample-App})
+        @headers({"User-Agent": "Uplink-Sample-App"})
         @get("/user")
         def get_user(self):
             \"""Get the current user\"""
@@ -119,32 +139,53 @@ class headers(MethodAnnotation):
 
     .. code-block:: python
 
-        @headers({"Accept": "application/vnd.github.v3.full+json")
+        @headers({"Accept": "application/vnd.github.v3.full+json"})
         class GitHub(Consumer):
             ...
 
     :py:class:`headers` takes the same arguments as :py:class:`dict`.
 
     Args:
-        *arg: A dict containing header values.
+        arg: A dict containing header values.
         **kwargs: More header values.
     """
-
     def __init__(self, arg, **kwargs):
-        if isinstance(arg, str):
-            key, value = self._get_header(arg)
-            self._headers = {key: value}
-        elif isinstance(arg, list):
-            self._headers = dict(self._get_header(a) for a in arg)
-        else:
-            self._headers = dict(arg, **kwargs)
+        super(headers, self).__init__("headers", arg, **kwargs)
 
-    def _get_header(self, arg):
-        return map(str.strip, arg.split(":"))
 
-    def modify_request(self, request_builder):
-        """Updates header contents."""
-        request_builder.info["headers"].update(self._headers)
+# noinspection PyPep8Naming
+class params(MethodAnnotation):
+    """
+    # TODO: Update tutorial to illustrate that there you can use
+    # this class to set static query parameters, much like the
+    # the difference between Header and headers.
+
+    A decorator that adds static query parameters for API calls.
+
+    .. code-block:: python
+
+        @params({"sort": "created"})
+        @get("/user")
+        def get_user(self):
+            \"""Get the current user\"""
+
+    When used as a class decorator, :py:class:`params` applies to
+    all consumer methods bound to the class:
+
+    .. code-block:: python
+
+        @params({"client_id": "my-app-client-id"})
+        class GitHub(Consumer):
+            ...
+
+    :py:class:`params` takes the same arguments as :py:class:`dict`.
+
+    Args:
+        arg: A dict containing query parameters.
+        **kwargs: More query parameters.
+    """
+    def __init__(self, arg, **kwargs):
+        super(params, self).__init__("params", arg, **kwargs)
 
 
 # noinspection PyPep8Naming


### PR DESCRIPTION
Similar to the `headers` decorator,  params adds static query parameters for API calls.

```python
@params({"sort": "created"})
@get("/user")
def get_user(self):
    """Get the current user"""
```

When used as a class decorator, :py:class:`params` applies to
all consumer methods bound to the class:

```python
@params({"client_id": "my-app-client-id"})
class GitHub(Consumer):
    ...
```

`params` takes the same arguments as `dict`.