### PR TITLE
Add `session` property to `Consumer` base class

### DIFF
--- a/docs/source/auth.rst
+++ b/docs/source/auth.rst
@@ -40,6 +40,16 @@ arguments`):
         def __init__(self, base_url, access_token: Query)
             ...
 
+or persist it through the :obj:`session` property (see :ref:`session property`):
+
+.. code-block:: python
+
+    class GitHub(Consumer):
+
+        def __init__(self, base_url, credentials):
+            self.session.params["access_token"] = self._get_access_token(credentials)
+            ...
+
 
 Using Auth Support for Requests and aiohttp
 -------------------------------------------

--- a/docs/source/consumer.rst
+++ b/docs/source/consumer.rst
@@ -1,0 +1,15 @@
+The Base Consumer Class
+=======================
+
+Consumer
+--------
+
+.. autoclass:: uplink.Consumer
+    :members:
+
+
+Session
+-------
+
+.. autoclass:: uplink.session.Session()
+    :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -94,6 +94,7 @@ This guide details the classes and methods in Uplink's public API.
 .. toctree::
    :maxdepth: 2
 
+   consumer.rst
    decorators.rst
    types.rst
    clients.rst

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -334,15 +334,19 @@ authenticated with the access token passed in at initialization:
     # This request will include the above access token as a query parameter.
     github.update_user(bio="Beam me up, Scotty!")
 
-:py:meth:`_inject` Request Properties
-=====================================
+The Consumer's :obj:`session` Property
+======================================
 
-.. versionadded:: 0.4.0
+.. versionadded:: 0.6.0
 
-As an alternative to :ref:`annotating constructor arguments`, you can achieve
-a similar behavior with more control by using the
-:py:meth:`Consumer._inject` method. With this method, you can calculate
-request properties within plain old python methods.
+The :py:obj:`session` property exposes configuration and allows for the
+persistence of certain request properties across any request
+
+of a :py:class:`~uplink.Consumer` instances
+
+As an alternative to :ref:`annotating constructor arguments`, you can provide
+default data (such as headers or query parameters) for all requests sent from
+the consumer instance:
 
 .. code-block:: python
 
@@ -351,10 +355,16 @@ request properties within plain old python methods.
         def __init__(self, username, password)
             # Create an access token
             api_key = create_api_key(username, password)
+            self.session.params["api_key"] = api_key
 
-            # Inject it.
-            self._inject(uplink.Query("api_key").with_value(api_key))
+        # Both 'api_key' and 'sort_by' are sent by this method
+        def get_todos(self, sort: uplink.Query("sort_by")):
+            """Retrieves all todo items."""
 
-Similar to the annotation style, request properties added with
-:py:meth:`~uplink.Consumer._inject` method are applied to all requests made
-through the consumer instance.
+Similar to the annotation style, request properties added through the
+session property are applied to all requests made from the consumer instance.
+
+Further, the session's dictionary properties (e.g., :obj:`headers` and
+:obj:`params`) are merged with the corresponding method-level properties.
+Notably, the method-level properties override the session's, but the
+method-level properties are not persisted across requests.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -159,7 +159,6 @@ function parameter annotation:
     def get_user(self, authorization: Header):
         """Get an authenticated user."""
 
-
 Synchronous vs. Asynchronous
 ============================
 
@@ -331,8 +330,12 @@ authenticated with the access token passed in at initialization:
 
     github = TodoApp("my-github-access-token")
 
-    # This request will include the above access token as a query parameter.
+    # This request will include the `access_token` query parameter set from
+    # the constructor argument.
     github.update_user(bio="Beam me up, Scotty!")
+
+
+.. _`session property`:
 
 The Consumer's :obj:`session` Property
 ======================================
@@ -340,13 +343,12 @@ The Consumer's :obj:`session` Property
 .. versionadded:: 0.6.0
 
 The :py:obj:`session` property exposes configuration and allows for the
-persistence of certain request properties across any request
+persistence of certain request properties across requests sent from a
+:py:class:`~uplink.Consumer` instances
 
-of a :py:class:`~uplink.Consumer` instances
-
-As an alternative to :ref:`annotating constructor arguments`, you can provide
-default data (such as headers or query parameters) for all requests sent from
-the consumer instance:
+As an alternative to :ref:`annotating constructor arguments`, you can
+provide default headers and query parameters for all requests sent from
+the consumer instance through the :py:obj:`session` property:
 
 .. code-block:: python
 
@@ -357,14 +359,14 @@ the consumer instance:
             api_key = create_api_key(username, password)
             self.session.params["api_key"] = api_key
 
-        # Both 'api_key' and 'sort_by' are sent by this method
-        def get_todos(self, sort: uplink.Query("sort_by")):
+        # Both 'api_key' and 'sort_by' are sent
+        def get_todos(self, sort_by: uplink.Query("sort_by")):
             """Retrieves all todo items."""
 
-Similar to the annotation style, request properties added through the
-session property are applied to all requests made from the consumer instance.
+Similar to the annotation style, headers and query parameters added
+through the :obj:`session` are applied to all requests sent from the
+consumer instance.
 
-Further, the session's dictionary properties (e.g., :obj:`headers` and
-:obj:`params`) are merged with the corresponding method-level properties.
-Notably, the method-level properties override the session's, but the
-method-level properties are not persisted across requests.
+Notably, in case of conflicts, the method-level headers and parameters
+override the session-level, but these method-level properties are not
+persisted across requests.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -337,29 +337,31 @@ authenticated with the access token passed in at initialization:
 
 .. _`session property`:
 
-The Consumer's :obj:`session` Property
-======================================
+Persistence Across Requests from a :obj:`Consumer`
+==================================================
 
 .. versionadded:: 0.6.0
 
-The :py:obj:`session` property exposes configuration and allows for the
-persistence of certain request properties across requests sent from a
-:py:class:`~uplink.Consumer` instances
+The :py:obj:`session` property of a :class:`~uplink.Consumer` instance exposes
+the instance's configuration and allows for the persistence of certain
+properties across requests sent from that instance.
 
 As an alternative to :ref:`annotating constructor arguments`, you can
-provide default headers and query parameters for all requests sent from
-the consumer instance through the :py:obj:`session` property:
+provide default headers and query parameters for requests sent from a
+consumer instance through its :py:obj:`session` property:
 
 .. code-block:: python
 
     class TodoApp(uplink.Consumer):
 
         def __init__(self, username, password)
-            # Create an access token
+            # Creates the API token for this user
             api_key = create_api_key(username, password)
+
+            # Send the API token as a query parameter with each request.
             self.session.params["api_key"] = api_key
 
-        # Both 'api_key' and 'sort_by' are sent
+        # Both 'api_key' and 'sort_by' are sent.
         def get_todos(self, sort_by: uplink.Query("sort_by")):
             """Retrieves all todo items."""
 
@@ -368,5 +370,5 @@ through the :obj:`session` are applied to all requests sent from the
 consumer instance.
 
 Notably, in case of conflicts, the method-level headers and parameters
-override the session-level, but these method-level properties are not
+override the session-level, but the method-level properties are not
 persisted across requests.

--- a/docs/source/types.rst
+++ b/docs/source/types.rst
@@ -16,25 +16,21 @@ Query
 =====
 
 .. autoclass:: uplink.Query
-   :members: with_value
 
 QueryMap
 ========
 
 .. autoclass:: uplink.QueryMap
-   :members: with_value
 
 Header
 ======
 
 .. autoclass:: uplink.Header
-   :members: with_value
 
 HeaderMap
 =========
 
 .. autoclass:: uplink.HeaderMap
-   :members: with_value
 
 Field
 =====

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -19,7 +19,7 @@ def test_headers(uplink_builder_mock):
     sess.headers["key"] = "value"
 
     # Verify
-    uplink_builder_mock.add_hook.assert_called()
+    assert uplink_builder_mock.add_hook.called
     assert sess.headers == {"key": "value"}
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -31,7 +31,7 @@ def test_params(uplink_builder_mock):
     sess.params["key"] = "value"
 
     # Verify
-    uplink_builder_mock.add_hook.assert_called()
+    assert uplink_builder_mock.add_hook.called
     assert sess.params == {"key": "value"}
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,55 @@
+# Local imports
+from uplink import session
+
+
+def test_base_url(uplink_builder_mock):
+    # Setup
+    uplink_builder_mock.base_url = "https://api.github.com"
+    sess = session.Session(uplink_builder_mock)
+
+    # Run & Verify
+    assert uplink_builder_mock.base_url == sess.base_url
+
+
+def test_headers(uplink_builder_mock):
+    # Setup
+    sess = session.Session(uplink_builder_mock)
+
+    # Run
+    sess.headers["key"] = "value"
+
+    # Verify
+    uplink_builder_mock.add_hook.assert_called()
+    assert sess.headers == {"key": "value"}
+
+
+def test_params(uplink_builder_mock):
+    # Setup
+    sess = session.Session(uplink_builder_mock)
+
+    # Run
+    sess.params["key"] = "value"
+
+    # Verify
+    uplink_builder_mock.add_hook.assert_called()
+    assert sess.params == {"key": "value"}
+
+
+def test_auth(uplink_builder_mock):
+    # Setup
+    uplink_builder_mock.auth = ("username", "password")
+    sess = session.Session(uplink_builder_mock)
+
+    # Run & Verify
+    assert uplink_builder_mock.auth == sess.auth
+
+
+def test_auth_set(uplink_builder_mock):
+    # Setup
+    sess = session.Session(uplink_builder_mock)
+
+    # Run
+    sess.auth = ("username", "password")
+
+    # Verify
+    assert ("username", "password") == uplink_builder_mock.auth

--- a/uplink/arguments.py
+++ b/uplink/arguments.py
@@ -244,7 +244,7 @@ class FuncDecoratorMixin(object):
     def with_value(self, value):
         """
         Creates an object that can be used with the
-        :py:class:`Consumer._inject` method or
+        :py:class:`Session.inject` method or
         :py:class:`~uplink.inject` decorator to inject request properties
         with specific values.
 

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -234,7 +234,6 @@ class Consumer(interfaces.Consumer, _Consumer):
         client = GitHub("https://api.github.com/")
         client.get_user("prkumar").json()  # {'login': 'prkumar', ... }
 
-
     Args:
         base_url (:obj:`str`, optional): The base URL for any request
             sent from this consumer instance.
@@ -262,15 +261,15 @@ class Consumer(interfaces.Consumer, _Consumer):
             auth=None,
             hook=()
     ):
-        self.__builder = Builder()
-        self.__builder.base_url = base_url
-        self.__builder.converters = converter
+        builder = Builder()
+        builder.base_url = base_url
+        builder.converters = converter
         if isinstance(hook, hooks.TransactionHook):
             hook = (hook,)
-        self.__builder.add_hook(*hook)
-        self.__builder.auth = auth
-        self.__builder.client = client
-        self.__session = session.Session(self.__builder)
+        builder.add_hook(*hook)
+        builder.auth = auth
+        builder.client = client
+        self.__session = session.Session(builder)
 
     def _inject(self, hook, *more_hooks):
         self.session.inject(hook, *more_hooks)

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -12,6 +12,7 @@ from uplink import (
     helpers,
     hooks,
     interfaces,
+    session,
     utils
 )
 
@@ -164,7 +165,7 @@ class ConsumerMethod(object):
         if instance is None:
             return self._request_definition_builder
         else:
-            return instance._builder.build(self._request_definition)
+            return instance.session.create(self._request_definition)
 
 
 class ConsumerMeta(type):
@@ -193,7 +194,7 @@ class ConsumerMeta(type):
                     handler.handle_call_args, call_args=call_args
                 )
                 hook = hooks.RequestAuditor(f)
-                self._builder.add_hook(hook)
+                self.session.inject(hook)
 
             namespace["__init__"] = new_init
 
@@ -215,6 +216,43 @@ _Consumer = ConsumerMeta("_Consumer", (), {})
 
 
 class Consumer(interfaces.Consumer, _Consumer):
+    """
+    Base consumer class with which to define custom consumers.
+
+    Example usage:
+
+    .. code-block:: python
+
+        from uplink import Consumer, get
+
+        class GitHub(Consumer):
+
+            @get("/users/{user}")
+            def get_user(self, user):
+                pass
+
+        client = GitHub("https://api.github.com/")
+        client.get_user("prkumar").json()  # {'login': 'prkumar', ... }
+
+
+    Args:
+        base_url (:obj:`str`, optional): The base URL for any request
+            sent from this consumer instance.
+        client (optional): A supported HTTP client instance (e.g.,
+            a :class:`requests.Session`) or an adapter (e.g.,
+            :class:`~uplink.RequestsClient`).
+        converter (:class:`ConverterFactory` or :obj:`tuple`, optional):
+            One or more objects that encapsulate custom
+            (de)serialization strategies for request properties and/or
+            the response body. (E.g.,
+            :class:`~uplink.converters.MarshmallowConverter`)
+        auth (:obj:`tuple` or :obj:`callable`, optional): The
+            authentication object for this consumer instance.
+        hook (:class:`~uplink.hooks.TransactionHook` or :obj:`tuple`):
+            One or more hooks to modify behavior of request execution
+            and response handling (see :class:`~uplink.response_handler`
+            or :class:`~uplink.error_handler`).
+    """
 
     def __init__(
             self,
@@ -224,17 +262,45 @@ class Consumer(interfaces.Consumer, _Consumer):
             auth=None,
             hook=()
     ):
-        self._builder = Builder()
-        self._builder.base_url = base_url
-        self._builder.converters = converter
+        self.__builder = Builder()
+        self.__builder.base_url = base_url
+        self.__builder.converters = converter
         if isinstance(hook, hooks.TransactionHook):
             hook = (hook,)
-        self._builder.add_hook(*hook)
-        self._builder.auth = auth
-        self._builder.client = client
+        self.__builder.add_hook(*hook)
+        self.__builder.auth = auth
+        self.__builder.client = client
+        self.__session = session.Session(self.__builder)
 
     def _inject(self, hook, *more_hooks):
-        self._builder.add_hook(hook, *more_hooks)
+        self.session.inject(hook, *more_hooks)
+
+    @property
+    def session(self):
+        """
+        The :class:`~uplink.session.Session` object for this consumer
+        instance.
+
+        Exposes the configuration of this :class:`~uplink.Consumer`
+        instance and allows the persistence of certain properties across
+        all requests sent from that instance.
+
+        Example usage:
+
+        .. code-block:: python
+
+            import uplink
+
+            class MyConsumer(uplink.Consumer):
+                def __init__(self, language):
+                    # Set this header for all requests of the instance.
+                    self.session.headers["Accept-Language"] = language
+                    ...
+
+        Returns:
+            :class:`~uplink.session.Session`
+        """
+        return self.__session
 
 
 def build(service_cls, *args, **kwargs):

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -491,13 +491,5 @@ class inject(_InjectableMethodAnnotation, hooks.TransactionHookChain):
     """
     A decorator that applies one or more hooks to a request method.
 
-    Example:
-        .. code-block:: python
-
-            @inject(Query("sort").with_value("pushed"))
-            @get("users/{user}/repos")
-            def list_repos(self, user):
-                \"""Lists user's public repos by latest pushed.\"""
-
     .. versionadded:: 0.4.0
     """

--- a/uplink/interfaces.py
+++ b/uplink/interfaces.py
@@ -132,8 +132,14 @@ class CallBuilder(object):
     def hooks(self):
         raise NotImplementedError
 
+    def add_hook(self, hook, *more_hooks):
+        raise NotImplementedError
+
     @property
     def auth(self):
+        raise NotImplementedError
+
+    def build(self, definition):
         raise NotImplementedError
 
 
@@ -142,5 +148,9 @@ class Auth(object):
     def __call__(self, request_builder):
         raise NotImplementedError
 
+
 class Consumer(object):
-    pass
+
+    @property
+    def session(self):
+        raise NotImplementedError

--- a/uplink/session.py
+++ b/uplink/session.py
@@ -1,0 +1,66 @@
+# Local imports
+from uplink import arguments
+
+
+class Session(object):
+    """
+    The session of a :class:`~uplink.Consumer` instance.
+
+    Exposes the configuration of a :class:`~uplink.Consumer` instance and
+    allows the persistence of certain properties across all requests sent
+    from that instance.
+    """
+
+    def __init__(self, builder):
+        self.__builder = builder
+        self.__params = None
+        self.__headers = None
+
+    def create(self, definition):
+        return self.__builder.build(definition)
+
+    @property
+    def base_url(self):
+        """
+        The base URL for any requests sent from this consumer instance.
+        """
+        return self.__builder.base_url
+
+    @property
+    def headers(self):
+        """
+        A dictionary of headers to be sent on each request from this
+        consumer instance.
+        """
+        if self.__headers is None:
+            self.__headers = {}
+            self.inject(arguments.HeaderMap().with_value(self.__headers))
+        return self.__headers
+
+    @property
+    def params(self):
+        """
+        A dictionary of querystring data to attach to each request from
+        this consumer instance.
+        """
+        if self.__params is None:
+            self.__params = {}
+            self.inject(arguments.QueryMap().with_value(self.__params))
+        return self.__params
+
+    @property
+    def auth(self):
+        """The authentication object for this consumer instance."""
+        return self.__builder.auth
+
+    @auth.setter
+    def auth(self, auth):
+        self.__builder.auth = auth
+
+    def inject(self, hook, *more_hooks):
+        """
+        Add hooks (e.g., functions decorated with either
+        :class:`~uplink.response_handler` or
+        :class:`~uplink.error_handler`) to the session.
+        """
+        self.__builder.add_hook(hook, *more_hooks)


### PR DESCRIPTION
The following feature was initially proposed by @liiight:

The `session` property of a `uplink.Consumer` instance exposes the instance's configuration and allows for the persistence of certain properties across requests sent from that instance.

Users can provide default headers and query parameters for requests sent from a consumer instance through its `session` property:

```python
class TodoApp(uplink.Consumer):

    def __init__(self, username, password)
        # Creates the API token for this user
        api_key = create_api_key(username, password)

        # Send the API token as a query parameter with each request.
        self.session.params["api_key"] = api_key

    # Both 'api_key' and 'sort_by' are sent.
    def get_todos(self, sort_by: uplink.Query("sort_by")):
        """Retrieves all todo items."""
```

Similar to the annotation style, headers and query parameters added through the `session` are applied to all requests sent from the consumer instance.

Notably, in case of conflicts, the method-level headers and parameters override the session-level, but the method-level properties are not persisted across requests.