### PR TITLE
Support registering aiohttp.ClientSession.close coroutine at exit

### DIFF
--- a/uplink/clients/aiohttp_.py
+++ b/uplink/clients/aiohttp_.py
@@ -75,12 +75,20 @@ class AiohttpClient(interfaces.HttpClientAdapter):
         if isinstance(self._session, self.__ARG_SPEC):
             args, kwargs = self._session
             self._session = aiohttp.ClientSession(*args, **kwargs)
-            atexit.register(
-                partial(
-                    asyncio.get_event_loop().run_until_complete,
-                    self._session.close(),
+
+            # aiohttp v3.0 has made ClientSession.close a coroutine,
+            # so we check whether it is one here and register it
+            # to run appropriately at exit
+            if asyncio.iscoroutinefunction(self._session.close):
+                atexit.register(
+                    partial(
+                        asyncio.get_event_loop().run_until_complete,
+                        self._session.close(),
+                    )
                 )
-            )
+            else:
+                atexit.register(self._session.close)
+
         return self._session
 
     def wrap_callback(self, callback):

--- a/uplink/clients/aiohttp_.py
+++ b/uplink/clients/aiohttp_.py
@@ -9,6 +9,7 @@ import asyncio
 import collections
 import threading
 from concurrent import futures
+from functools import partial
 
 # Third party imports
 try:
@@ -74,7 +75,12 @@ class AiohttpClient(interfaces.HttpClientAdapter):
         if isinstance(self._session, self.__ARG_SPEC):
             args, kwargs = self._session
             self._session = aiohttp.ClientSession(*args, **kwargs)
-            atexit.register(self._session.close)
+            atexit.register(
+                partial(
+                    asyncio.get_event_loop().run_until_complete,
+                    self._session.close(),
+                )
+            )
         return self._session
 
     def wrap_callback(self, callback):


### PR DESCRIPTION
Fixes #99 

Changes proposed in this pull request:
- Use `functools.partial` to register a partial for the `aiohttp.ClientSession.close` coroutine, running it in an event loop on exit instead.

P.S. I am fairly new to `asyncio`, so please excuse my ignorance if this is not the best method to do so.

Attention: @prkumar