### PR TITLE
Release Hotfix v0.5.4

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,4 @@ Contributors
 - Fabio Rosado (`@fabiorosado <https://github.com/fabiorosado>`_)
 - Niko Eckerskorn (`@kadrach <https://github.com/kadrach>`_)
 - Or Carmi (`@liiight <https://github.com/liiight>`_)
+- George Kontridze (`@gkze <https://github.com/gkze>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to the
 `Semantic Versioning`_ scheme.
 
+0.5.4_ - 2018-6-26
+==================
+Fixed
+-----
+- When using ``uplink.AiohttpClient`` with ``aiohttp>=3.0``, the underlying
+  ``aiohttp.ClientSession`` would remain open on program exit.
+
 0.5.3_ - 2018-5-31
 ==================
 Fixed
@@ -168,6 +175,7 @@ Added
 .. _`Semantic Versioning`: https://packaging.python.org/tutorials/distributing-packages/#semantic-versioning-preferred
 
 .. Releases
+.. _0.5.4: https://github.com/prkumar/uplink/compare/v0.5.3...v0.5.4
 .. _0.5.3: https://github.com/prkumar/uplink/compare/v0.5.2...v0.5.3
 .. _0.5.2: https://github.com/prkumar/uplink/compare/v0.5.1...v0.5.2
 .. _0.5.1: https://github.com/prkumar/uplink/compare/v0.5.0...v0.5.1

--- a/uplink/__about__.py
+++ b/uplink/__about__.py
@@ -3,4 +3,4 @@ This module is the single source of truth for any package metadata
 that is used both in distribution (i.e., setup.py) and within the
 codebase.
 """
-__version__ = "0.5.3"
+__version__ = "0.5.4"

--- a/uplink/clients/aiohttp_.py
+++ b/uplink/clients/aiohttp_.py
@@ -9,6 +9,7 @@ import collections
 import threading
 
 from concurrent import futures
+from functools import partial
 
 # Third party imports
 try:
@@ -74,7 +75,20 @@ class AiohttpClient(interfaces.HttpClientAdapter):
         if isinstance(self._session, self.__ARG_SPEC):
             args, kwargs = self._session
             self._session = aiohttp.ClientSession(*args, **kwargs)
-            atexit.register(self._session.close)
+
+            # aiohttp v3.0 has made ClientSession.close a coroutine,
+            # so we check whether it is one here and register it
+            # to run appropriately at exit
+            if asyncio.iscoroutinefunction(self._session.close):
+                atexit.register(
+                    partial(
+                        asyncio.get_event_loop().run_until_complete,
+                        self._session.close(),
+                    )
+                )
+            else:
+                atexit.register(self._session.close)
+
         return self._session
 
     def wrap_callback(self, callback):


### PR DESCRIPTION
Fixed
-----
- When using ``uplink.AiohttpClient`` with ``aiohttp>=3.0``, the underlying
  ``aiohttp.ClientSession`` would remain open on program exit. #100 