### PR TITLE
Update indentation on json decorator example

### DIFF
--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -286,12 +286,12 @@ class json(MethodAnnotation):
     specify JSON fields separately, across multiple arguments:
 
     Example:
-    .. code-block:: python
+        .. code-block:: python
 
-        @json
-        @patch(/user")
-        def update_user(self, name: Field, email: Field("e-mail"):
-            \"""Update the current user.\"""
+            @json
+            @patch(/user")
+            def update_user(self, name: Field, email: Field("e-mail"):
+                \"""Update the current user.\"""
 
     Further, to set a nested field, you can specify the path of the
     target field with a tuple of strings as the first argument of

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -290,7 +290,7 @@ class json(MethodAnnotation):
 
             @json
             @patch(/user")
-            def update_user(self, name: Field, email: Field("e-mail"):
+            def update_user(self, name: Field, email: Field("e-mail")):
                 \"""Update the current user.\"""
 
     Further, to set a nested field, you can specify the path of the


### PR DESCRIPTION
Small indentation change to fix the broken code block for the `json` decorator class on https://uplink.readthedocs.io/en/stable/decorators.html

Attention: @prkumar