### PR TITLE
Address changes to Schema().load and Schema().dump in marshmallow v3

### DIFF
--- a/examples/marshmallow/schemas.py
+++ b/examples/marshmallow/schemas.py
@@ -9,8 +9,15 @@ Contributor = collections.namedtuple(
 Repo = collections.namedtuple("Repo", field_names=["owner", "name"])
 
 
+class SchemaBase(marshmallow.Schema):
+    class Meta:
+        # Pass EXCLUDE as Meta option to keep marshmallow 2 behavior
+        # ref: https://marshmallow.readthedocs.io/en/3.0/upgrading.html
+        unknown = getattr(marshmallow, "EXCLUDE", None)
+
+
 # == Schemas == #
-class ContributorSchema(marshmallow.Schema):
+class ContributorSchema(SchemaBase):
     login = marshmallow.fields.Str(attribute="username")
     contributions = marshmallow.fields.Int()
 
@@ -19,7 +26,7 @@ class ContributorSchema(marshmallow.Schema):
         return Contributor(**data)
 
 
-class RepoSchema(marshmallow.Schema):
+class RepoSchema(SchemaBase):
     full_name = marshmallow.fields.Str()
 
     @marshmallow.post_load


### PR DESCRIPTION
After marshmallow 3.0, `Schema().load` and `Schema().dump` don't return a `(data, errors)` tuple any more. Only `data` is returned.

See: https://marshmallow.readthedocs.io/en/3.0/upgrading.html

This tiny PR accommodates these changes for our examples and integrations with `marshmallow`. 