### PR TITLE
Issue #113: Adds an example of repsonse_handler and error_handler

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,3 +10,4 @@ Contributors
 - Niko Eckerskorn (`@kadrach <https://github.com/kadrach>`_)
 - Or Carmi (`@liiight <https://github.com/liiight>`_)
 - George Kontridze (`@gkze <https://github.com/gkze>`_)
+- Sean Chambers (`@schambers <https://github.com/schambers>`_)

--- a/examples/handler_callbacks/README.md
+++ b/examples/handler_callbacks/README.md
@@ -1,0 +1,23 @@
+# Response and Error Handling Example
+
+---
+
+This example shows how to handle errors and responses via callbacks. These callbacks allow you
+to define error handlers and response handlers that can perform processing of the response
+from the remote server.
+
+Included are two examples:
+
+1. (response_handler) Get the google home page and print the response status code
+```
+google = Google(base_url=BASE_URL)
+google.homepage()
+Prints: Google response status: 200
+```
+
+2. (error_handler) Get an invalid url and prints the exception type
+```
+google = Google(base_url="NON_EXISTENT_URL")
+google.bad_page()
+Prints: Error Encountered. Exception will be raised...
+```

--- a/examples/handler_callbacks/Server.py
+++ b/examples/handler_callbacks/Server.py
@@ -1,0 +1,28 @@
+import sys
+
+# add uplink directory to path
+sys.path.insert(0, "../../")
+import uplink
+from uplink import *
+
+BASE_URL="https://www.google.com"
+
+def print_status(response):
+    print('Google response status:{}'.format(response.status_code))
+    return response
+
+def handle_error(exc_type, exc_val, exc_tb):
+    print ('Error encountered. Exception will be raised. Exception Type:{}'.format(exc_type))
+
+@headers({"Accept": "text/html"})
+class Google(Consumer):
+    @response_handler(print_status)
+    @get("/")
+    def homepage(self):
+        print('google home page')
+        pass
+
+    @error_handler(handle_error)
+    @get("/bad_page.html")
+    def bad_page(selfs):
+        pass

--- a/examples/handler_callbacks/handlers_example.py
+++ b/examples/handler_callbacks/handlers_example.py
@@ -1,0 +1,12 @@
+from Server import Google, BASE_URL
+
+def test_homepage():
+    google = Google(base_url=BASE_URL)
+    google.homepage()
+
+def test_error():
+    google = Google(base_url="NON_EXISTENT_URL")
+    google.bad_page()
+
+test_homepage()
+test_error()


### PR DESCRIPTION
Fixes #113  .

Changes proposed in this pull request:
- Adds an example of how to use response_handler and error_handler when crafting a proxy. The response_handler prints google.com response status code. error_handler purposely loads an invalid URL and prints some text indicating an error was encountered
- Add name to AUTHORS.rst

Attention: @prkumar