### PR TITLE
Let users specify if/how None values are encoded

### DIFF
--- a/tests/unit/test_arguments.py
+++ b/tests/unit/test_arguments.py
@@ -275,6 +275,18 @@ class TestQuery(ArgumentTestCase, FuncDecoratorTestCase):
                 request_builder, "value2"
             )
 
+    def test_skip_none(self, request_builder):
+        arguments.Query("name").modify_request(
+            request_builder, None
+        )
+        assert request_builder.info["params"] == {}
+
+    def test_encode_none(self, request_builder):
+        arguments.Query("name", encode_none="null").modify_request(
+            request_builder, None
+        )
+        assert request_builder.info["params"] == {"name": "null"}
+
     def test_converter_key_with_encoded(self):
         query = arguments.Query("name", encoded=True)
         assert query.converter_key == keys.CONVERT_TO_STRING


### PR DESCRIPTION
Fixes #125.

Changes proposed in this pull request:
- Adds an `encode_none` parameter to `Query` which lets users specify if at all, and if yes how a value of `None` should be sent to the service.

This changes behavior slightly: if a parameter is `None` (per its default value or because the user set it), previously it was encoded as `...?name=None`. To retain this behavior, a user would have to specify `Query(..., encode_none="None")`.

Attention: @prkumar