### PR TITLE
Add timeout argument annotation

### DIFF
--- a/docs/source/dev/types.rst
+++ b/docs/source/dev/types.rst
@@ -62,3 +62,8 @@ Url
 ===
 
 .. autoclass:: uplink.Url
+
+Timeout
+=======
+
+.. autoclass:: uplink.Timeout

--- a/tests/unit/test_arguments.py
+++ b/tests/unit/test_arguments.py
@@ -1,7 +1,3 @@
-try:
-    import mock
-except ImportError:
-    from unittest import mock
 import pytest
 
 # Local imports
@@ -432,7 +428,7 @@ class TestUrl(ArgumentTestCase):
 
 class TestTimeout(ArgumentTestCase, FuncDecoratorTestCase):
     type_cls = arguments.Timeout
-    expected_converter_key = mock.ANY
+    expected_converter_key = keys.Identity()
 
     def test_modify_request(self, request_builder):
         arguments.Timeout().modify_request(request_builder, 10)

--- a/tests/unit/test_arguments.py
+++ b/tests/unit/test_arguments.py
@@ -1,3 +1,7 @@
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 import pytest
 
 # Local imports
@@ -424,3 +428,12 @@ class TestUrl(ArgumentTestCase):
     def test_modify_request(self, request_builder):
         arguments.Url().modify_request(request_builder, "/some/path")
         assert request_builder.url == "/some/path"
+
+
+class TestTimeout(ArgumentTestCase, FuncDecoratorTestCase):
+    type_cls = arguments.Timeout
+    expected_converter_key = mock.ANY
+
+    def test_modify_request(self, request_builder):
+        arguments.Timeout().modify_request(request_builder, 10)
+        assert request_builder.info["timeout"] == 10

--- a/tests/unit/test_converters.py
+++ b/tests/unit/test_converters.py
@@ -312,6 +312,37 @@ class TestSequence(object):
         assert not (converters.keys.Sequence(1) == 1)
 
 
+class TestIdentity(object):
+    _sentinel = object()
+
+    @pytest.fixture(scope="class")
+    def registry(self):
+        return converters.ConverterFactoryRegistry(
+            (converters.StandardConverter(),)
+        )
+
+    @pytest.fixture(scope="class")
+    def key(self):
+        return converters.keys.Identity()
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (1, 1),
+            ("a", "a"),
+            (_sentinel, _sentinel),
+            ({"a": "b"}, {"a": "b"}),
+            ([1, 2], [1, 2]),
+        ],
+    )
+    def test_convert(self, registry, key, value, expected):
+        converter = registry[key]()
+        assert converter(value) == expected
+
+    def test_eq(self):
+        assert converters.keys.Identity() == converters.keys.Identity()
+
+
 class TestRegistry(object):
     @pytest.mark.parametrize(
         "converter",

--- a/uplink/__init__.py
+++ b/uplink/__init__.py
@@ -40,6 +40,7 @@ from uplink.arguments import (
     PartMap,
     Body,
     Url,
+    Timeout,
 )
 from uplink.ratelimit import ratelimit
 from uplink.retry import retry
@@ -88,6 +89,7 @@ __all__ = [
     "PartMap",
     "Body",
     "Url",
+    "Timeout",
     "retry",
     "ratelimit",
 ]

--- a/uplink/arguments.py
+++ b/uplink/arguments.py
@@ -675,3 +675,35 @@ class Url(ArgumentAnnotation):
     def _modify_request(cls, request_builder, value):
         """Updates request url."""
         request_builder.url = value
+
+
+class Timeout(FuncDecoratorMixin, ArgumentAnnotation):
+    """
+    Pass a timeout as a method argument at runtime.
+
+    While :py:class:`uplink.timeout` attaches static timeout to all requests
+    sent from a consumer method, this class turns a method argument into a
+    dynamic timeout value.
+
+    Example:
+        .. code-block:: python
+
+            @get("/user/posts")
+            def get_posts(self, timeout: Timeout() = 60):
+                \"""Fetch all posts for the current users giving up after given
+                number of seconds.\"""
+
+    """
+
+    @property
+    def type(self):
+        return float
+
+    @property
+    def converter_key(self):
+        """Do not Convert passed argument."""
+        return lambda converter_factory: lambda value: value
+
+    def _modify_request(self, request_builder, value):
+        """Modifies request timeout."""
+        request_builder.info["timeout"] = value

--- a/uplink/arguments.py
+++ b/uplink/arguments.py
@@ -702,7 +702,7 @@ class Timeout(FuncDecoratorMixin, ArgumentAnnotation):
 
     @property
     def converter_key(self):
-        """Do not Convert passed argument."""
+        """Do not convert passed argument."""
         return keys.Identity()
 
     def _modify_request(self, request_builder, value):

--- a/uplink/arguments.py
+++ b/uplink/arguments.py
@@ -23,6 +23,7 @@ __all__ = [
     "PartMap",
     "Body",
     "Url",
+    "Timeout",
 ]
 
 

--- a/uplink/arguments.py
+++ b/uplink/arguments.py
@@ -702,7 +702,7 @@ class Timeout(FuncDecoratorMixin, ArgumentAnnotation):
     @property
     def converter_key(self):
         """Do not Convert passed argument."""
-        return lambda converter_factory: lambda value: value
+        return keys.Identity()
 
     def _modify_request(self, request_builder, value):
         """Modifies request timeout."""

--- a/uplink/converters/keys.py
+++ b/uplink/converters/keys.py
@@ -86,3 +86,22 @@ class Sequence(CompositeKey):
             return list(map(converter, value))
         else:
             return converter(value)
+
+
+class Identity(object):
+    """
+    Identity conversion - pass value as is
+    """
+
+    def __eq__(self, other):
+        return isinstance(other, Identity) and type(other) is type(self)
+
+    def __call__(self, converter_registry):
+
+        def factory_wrapper(*args, **kwargs):
+            return self._identity
+
+        return factory_wrapper
+
+    def _identity(self, value):
+        return value

--- a/uplink/converters/keys.py
+++ b/uplink/converters/keys.py
@@ -93,15 +93,14 @@ class Identity(object):
     Identity conversion - pass value as is
     """
 
-    def __eq__(self, other):
-        return isinstance(other, Identity) and type(other) is type(self)
-
     def __call__(self, converter_registry):
+        return self._identity_factory
 
-        def factory_wrapper(*args, **kwargs):
-            return self._identity
+    def __eq__(self, other):
+        return type(other) is type(self)
 
-        return factory_wrapper
+    def _identity_factory(self, *args, **kwargs):
+        return self._identity
 
     def _identity(self, value):
         return value


### PR DESCRIPTION
Fixes #131 .

Changes proposed in this pull request:
- add ``Timeout`` argument annotation to be able to pass timeout as consumer method argument or to inject it as transaction hook
- add ``Identity`` converter key to pass given value as is to use it in ``Timeout`` described above

Attention: @prkumar