### PR TITLE
Enhance @retry decorator with `when` argument

### DIFF
--- a/docs/source/user/quickstart.rst
+++ b/docs/source/user/quickstart.rst
@@ -495,7 +495,28 @@ argument:
       def get_user(self, username):
          """Get user by username."""
 
-Like other Uplink decorators, you can decorate a :class:`Consumer`
+The :class:`@retry <uplink.retry>` decorators offers a bunch of other
+features! Below is a contrived example... checkout the
+:ref:`API documentation <retry_api>` for more:
+
+.. code-block:: python
+
+   from uplink import retry, Consumer, get
+
+   class GitHub(Consumer):
+      @retry(
+         # Retry on 503 response status code or any exception.
+         when=retry.when.status(503) | retry.when.raises(Exception)
+         # Stop after 5 attempts or when backoff exceeds 10 seconds.
+         stop=retry.stop.after_attempt(5) | retry.stop.after_delay(10)
+         # Use exponential backoff with added randomness.
+         backoff=retry.backoff.jittered(multiplier=0.5)
+      )
+      @get("user/{username}")
+      def get_user(self, username):
+         """Get user by username."""
+
+Finally, like other Uplink decorators, you can decorate a :class:`Consumer`
 subclass with :class:`@retry <uplink.retry>` to :ref:`add retry support to all
 methods of that class <decorate_consumer>`.
 

--- a/tests/unit/test_clients.py
+++ b/tests/unit/test_clients.py
@@ -264,13 +264,15 @@ class TestAiohttp(object):
         assert isinstance(aiohttp.create_request(), aiohttp_.Request)
 
     @requires_python34
-    def test_request_send(self, aiohttp_session_mock):
+    def test_request_send(self, mocker, aiohttp_session_mock):
         # Setup
         import asyncio
 
+        expected_response = mocker.Mock()
+
         @asyncio.coroutine
         def request(*args, **kwargs):
-            return 0
+            return expected_response
 
         aiohttp_session_mock.request = request
         client = aiohttp_.AiohttpClient(aiohttp_session_mock)
@@ -282,16 +284,18 @@ class TestAiohttp(object):
         value = loop.run_until_complete(asyncio.ensure_future(response))
 
         # Verify
-        assert value == 0
+        assert value == expected_response
 
     @requires_python34
-    def test_callback(self, aiohttp_session_mock):
+    def test_callback(self, mocker, aiohttp_session_mock):
         # Setup
         import asyncio
 
+        expected_response = mocker.Mock()
+
         @asyncio.coroutine
         def request(*args, **kwargs):
-            return 2
+            return expected_response
 
         aiohttp_session_mock.request = request
         client = aiohttp_.AiohttpClient(aiohttp_session_mock)
@@ -430,6 +434,7 @@ class TestAiohttp(object):
         import asyncio
         import gc
         import aiohttp
+
         mock_session = mocker.Mock(spec=aiohttp.ClientSession)
         session_cls_mock = mocker.patch("aiohttp.ClientSession")
         session_cls_mock.return_value = mock_session

--- a/uplink/clients/aiohttp_.py
+++ b/uplink/clients/aiohttp_.py
@@ -73,7 +73,8 @@ class AiohttpClient(interfaces.HttpClientAdapter):
             # to run appropriately at exit
             if asyncio.iscoroutinefunction(self._session.close):
                 asyncio.get_event_loop().run_until_complete(
-                    self._session.close())
+                    self._session.close()
+                )
             else:
                 self._session.close()
 
@@ -144,6 +145,10 @@ class Request(helpers.ExceptionHandlerMixin, interfaces.Request):
         session = yield from self._client.session()
         with self._exception_handler:
             response = yield from session.request(method, url, **extras)
+
+        # Make `aiohttp` response "quack" like a `requests` response
+        response.status_code = response.status
+
         if self._callback is not None:
             response = yield from self._callback(response)
         return response

--- a/uplink/retry/__init__.py
+++ b/uplink/retry/__init__.py
@@ -1,3 +1,4 @@
 from uplink.retry.retry import retry
+from uplink.retry.when import RetryPredicate
 
-__all__ = ["retry"]
+__all__ = ["retry", "RetryPredicate"]

--- a/uplink/retry/_helpers.py
+++ b/uplink/retry/_helpers.py
@@ -1,0 +1,10 @@
+class ClientExceptionProxy(object):
+    def __init__(self, getter):
+        self._getter = getter
+
+    @classmethod
+    def wrap_proxy_if_necessary(cls, exc):
+        return exc if isinstance(exc, cls) else (lambda exceptions: exc)
+
+    def __call__(self, exceptions):
+        return self._getter(exceptions)

--- a/uplink/retry/retry.py
+++ b/uplink/retry/retry.py
@@ -1,37 +1,39 @@
 # Local imports
 from uplink import decorators
 from uplink.clients.io import RequestTemplate, transitions
-from uplink.retry import stop as stop_mod, backoff as backoff_mod
+from uplink.retry import (
+    when as when_mod,
+    stop as stop_mod,
+    backoff as backoff_mod,
+)
+from uplink.retry._helpers import ClientExceptionProxy
 
 __all__ = ["retry"]
 
 
-class _ClientExceptionProxy(object):
-    def __init__(self, getter):
-        self._getter = getter
-
-    @classmethod
-    def wrap_proxy_if_necessary(cls, exc):
-        return exc if isinstance(exc, cls) else (lambda exceptions: exc)
-
-    def __call__(self, exceptions):
-        return self._getter(exceptions)
-
-
 class RetryTemplate(RequestTemplate):
-    def __init__(self, back_off_iterator, failure_tester):
+    def __init__(self, back_off_iterator, retry_condition):
         self._back_off_iterator = back_off_iterator
-        self._should_retry = failure_tester
+        self._condition = retry_condition
+
+    def _next_delay(self):
+        try:
+            delay = next(self._back_off_iterator)
+        except StopIteration:
+            # Fallback to the default behavior
+            pass
+        else:
+            return transitions.sleep(delay)
+
+    def after_response(self, request, response):
+        if self._condition.should_retry_after_response(response):
+            return self._next_delay()
 
     def after_exception(self, request, exc_type, exc_val, exc_tb):
-        if self._should_retry(exc_type, exc_val, exc_tb):
-            try:
-                delay = next(self._back_off_iterator)
-            except StopIteration:
-                # Fallback to the default behavior
-                pass
-            else:
-                return transitions.sleep(delay)
+        if self._condition.should_retry_after_exception(
+            exc_type, exc_val, exc_tb
+        ):
+            return self._next_delay()
 
 
 # noinspection PyPep8Naming
@@ -40,25 +42,25 @@ class retry(decorators.MethodAnnotation):
     A decorator that adds retry support to a consumer method or to an
     entire consumer.
 
-    Unless you specify the ``on_exception`` argument, all failed
-    requests are retried.
+    Unless you specify the ``when`` or ``on_exception`` argument, all
+    failed requests that raise an exception are retried.
 
     Unless you specify the ``max_attempts`` or ``stop`` argument, this
     decorator continues retrying until the server returns a response.
 
-    Unless you specify the ``wait`` argument, this decorator uses
+    Unless you specify the ``backoff`` argument, this decorator uses
     `capped exponential backoff and jitter <https://amzn.to/2xc2nK2>`_,
     which should benefit performance with remote services under high
     contention.
 
     Args:
+        when (optional): A predicate that determines when a retry
+            should be attempted.
         max_attempts (int, optional): The number of retries to attempt.
             If not specified, requests are retried continuously until
             a response is rendered.
         on_exception (:class:`Exception`, optional): The exception type
-            that should prompt a retry attempt. The default value is
-            :class:`Exception`, meaning all failed requests are
-            retried.
+            that should prompt a retry attempt.
         stop (:obj:`callable`, optional): A function that creates
             predicates that decide when to stop retrying a request.
         backoff (:obj:`callable`, optional): A function that creates
@@ -66,43 +68,40 @@ class retry(decorators.MethodAnnotation):
             retries. If not specified, exponential backoff is used.
     """
 
+    _DEFAULT_PREDICATE = when_mod.raises(Exception)
+
     def __init__(
-        self, max_attempts=None, on_exception=Exception, stop=None, backoff=None
+        self,
+        when=None,
+        max_attempts=None,
+        on_exception=None,
+        stop=None,
+        backoff=None,
     ):
         if stop is not None:
             self._stop = stop
         elif max_attempts is not None:
-            self._stop = stop_mod.after_attempts(max_attempts)
+            self._stop = stop_mod.after_attempt(max_attempts)
         else:
             self._stop = stop_mod.DISABLE
 
-        self._backoff = backoff_mod.jittered() if backoff is None else backoff
-        self._when = self._when_exception_type_is(on_exception)
+        self._predicate = when
 
-    BASE_CLIENT_EXCEPTION = _ClientExceptionProxy(
+        if on_exception is not None:
+            self._predicate = when_mod.raises(on_exception) | self._predicate
+
+        if self._predicate is None:
+            self._predicate = self._DEFAULT_PREDICATE
+
+        self._backoff = backoff_mod.jittered() if backoff is None else backoff
+
+    BASE_CLIENT_EXCEPTION = ClientExceptionProxy(
         lambda ex: ex.BaseClientException
     )
-    CONNECTION_ERROR = _ClientExceptionProxy(lambda ex: ex.ConnectionError)
-    CONNECTION_TIMEOUT = _ClientExceptionProxy(lambda ex: ex.ConnectionTimeout)
-    SERVER_TIMEOUT = _ClientExceptionProxy(lambda ex: ex.ServerTimeout)
-    SSL_ERROR = _ClientExceptionProxy(lambda ex: ex.SSLError)
-
-    @staticmethod
-    def _when_exception_type_is(exc_type):
-        """
-        Attempts retry when the raised exception type is ``exc_type``.
-        """
-        proxy = _ClientExceptionProxy.wrap_proxy_if_necessary(exc_type)
-
-        def when_func(rb):
-            type_ = proxy(rb.client.exceptions)
-
-            def should_retry(et, ev, tb):
-                return isinstance(ev, type_)
-
-            return should_retry
-
-        return when_func
+    CONNECTION_ERROR = ClientExceptionProxy(lambda ex: ex.ConnectionError)
+    CONNECTION_TIMEOUT = ClientExceptionProxy(lambda ex: ex.ConnectionTimeout)
+    SERVER_TIMEOUT = ClientExceptionProxy(lambda ex: ex.ServerTimeout)
+    SSL_ERROR = ClientExceptionProxy(lambda ex: ex.SSLError)
 
     def modify_request(self, request_builder):
         request_builder.add_request_template(
@@ -111,15 +110,17 @@ class retry(decorators.MethodAnnotation):
 
     def _create_template(self, request_builder):
         return RetryTemplate(
-            self._backoff_iterator(), self._when(request_builder)
+            self._backoff_iterator(), self._predicate(request_builder)
         )
 
     def _backoff_iterator(self):
-        should_stop = self._stop()
+        stop_gen = self._stop()
         for delay in self._backoff():
-            if should_stop():
+            next(stop_gen)
+            if stop_gen.send(delay):
                 break
             yield delay
 
     stop = stop_mod
     backoff = backoff_mod
+    when = when_mod

--- a/uplink/retry/stop.py
+++ b/uplink/retry/stop.py
@@ -1,25 +1,74 @@
 
-__all__ = ["after_attempts"]
+__all__ = ["after_attempt", "after_delay"]
 
 
-class _AfterAttemptStopper(object):
-    def __init__(self, num):
-        self._num = num
+class RetryBreaker(object):
+    def __or__(self, other):
+        if other is not None:
+            assert isinstance(
+                other, RetryBreaker
+            ), "Both objects should be retry breakers."
+            return _Or(self, other)
+        return self
+
+    def __call__(self):  # pragma: no cover
+        raise NotImplementedError
+
+
+class _Or(RetryBreaker):
+    def __init__(self, left, right):
+        self._left = left
+        self._right = right
+
+    def __call__(self):
+        left = self._left()
+        right = self._right()
+        while True:
+            delay = yield
+            next(left)
+            next(right)
+            stop_left = left.send(delay)
+            stop_right = right.send(delay)
+            yield stop_left or stop_right
+
+
+# noinspection PyPep8Naming
+class after_attempt(RetryBreaker):
+    """Stops retrying after the specified number of ``attempts``."""
+
+    def __init__(self, attempt):
+        self._max_attempt = attempt
         self._attempt = 0
 
-    def __call__(self, *_):
-        self._attempt += 1
-        return self._num <= self._attempt
+    def __call__(self):
+        attempt = 0
+        while True:
+            yield
+            attempt += 1
+            yield self._max_attempt <= attempt
 
 
-def after_attempts(attempts):
-    """Stops retrying after the specified number of ``attempts``."""
-    return lambda: _AfterAttemptStopper(attempts)
+# noinspection PyPep8Naming
+class after_delay(RetryBreaker):
+    """
+    Stops retrying after the backoff exceeds the specified ``delay``
+    in seconds.
+    """
+
+    def __init__(self, delay):
+        self._max_delay = delay
+
+    def __call__(self):
+        while True:
+            delay = yield
+            yield self._max_delay < delay
 
 
-class _DisableStop(object):
-    def __call__(self, *args, **kwargs):
-        return False
+class _DisableStop(RetryBreaker):
+    def __call__(self):
+        while True:
+            yield
+            yield False
 
 
 DISABLE = _DisableStop()

--- a/uplink/retry/when.py
+++ b/uplink/retry/when.py
@@ -1,0 +1,84 @@
+# Local imports
+from uplink.retry._helpers import ClientExceptionProxy
+
+__all__ = ["RetryPredicate", "raises", "status", "bad_request"]
+
+
+class RetryPredicate(object):
+    def should_retry_after_response(self, response):
+        return False
+
+    def should_retry_after_exception(self, exc_type, exc_val, exc_tb):
+        return False
+
+    def __call__(self, request_builder):  # Pragma: no cover
+        return self
+
+    def __or__(self, other):
+        if other is not None:
+            assert isinstance(
+                other, RetryPredicate
+            ), "Both objects should be retry conditions."
+            return _Or(self, other)
+        return self
+
+
+class _Or(RetryPredicate):
+    def __init__(self, left, right):
+        self._left = left
+        self._right = right
+
+    def should_retry_after_response(self, *args, **kwargs):
+        return self._left.should_retry_after_response(
+            *args, **kwargs
+        ) or self._right.should_retry_after_response(*args, **kwargs)
+
+    def should_retry_after_exception(self, *args, **kwargs):
+        return self._left.should_retry_after_exception(
+            *args, **kwargs
+        ) or self._right.should_retry_after_exception(*args, **kwargs)
+
+    def __call__(self, request_builder):
+        left = self._left(request_builder)
+        right = self._right(request_builder)
+        return type(self)(left, right)
+
+
+# noinspection PyPep8Naming
+class raises(RetryPredicate):
+    """Retry when a specific exception type is raised."""
+
+    def __init__(self, expected_exception):
+        self._expected_exception = expected_exception
+
+    def __call__(self, request_builder):
+        proxy = ClientExceptionProxy.wrap_proxy_if_necessary(
+            self._expected_exception
+        )
+        type_ = proxy(request_builder.client.exceptions)
+        return raises(type_)
+
+    def should_retry_after_exception(self, exc_type, exc_val, exc_tb):
+        return isinstance(exc_val, self._expected_exception)
+
+
+# noinspection PyPep8Naming
+class status(RetryPredicate):
+    """Retry on specific HTTP response status codes."""
+
+    def __init__(self, *status_codes):
+        self._status_codes = status_codes
+
+    def should_retry_after_response(self, response):
+        return response.status_code in self._status_codes
+
+
+# noinspection PyPep8Naming
+class bad_request(RetryPredicate):
+    """
+    Retry after a bad request -- i.e., received response with 4xx
+    (client error) or 5xx (server error) response status code.
+    """
+
+    def should_retry_after_response(self, response):
+        return 400 <= response.status_code < 600


### PR DESCRIPTION
These changes add a `when` argument to the `@retry` decorator and also the `retry.when` module that exposes retry conditions. The `when` argument should be used to set a retry predicate/condition that details **when** a retry should be attempted. For example, the `retry.when.status` method is a predicate that prompts retries on a specific HTTP response status code. Also, these changes add support for joining retry predicates (e.g., `retry.when.*`) using the `|` operator. Further, the `|` operator can also be used with retry stopping strategies (e.g., `retry.stop.*`). Here's a simple example that illustrates some of these changes:

```python
   from uplink import retry, Consumer, get

   class GitHub(Consumer):
      @retry(
         # Retry on 503 response status code or any exception.
         when=retry.when.status(503) | retry.when.raises(Exception)
         # Stop after 5 attempts or when backoff exceeds 10 seconds.
         stop=retry.stop.after_attempt(5) | retry.stop.after_delay(10)
         # Use exponential backoff with added randomness.
         backoff=retry.backoff.jittered(multiplier=0.5)
      )
      @get("user/{username}")
      def get_user(self, username):
         """Get user by username."""
```