### PR TITLE
Keep a separate rate limit for each host-port combination

### DIFF
--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -25,7 +25,7 @@ def test_get_api_definitions_from_parent(request_definition_builder):
 class TestRequestBuilder(object):
     def test_return_type(self):
         # Setup
-        builder = helpers.RequestBuilder(None, {})
+        builder = helpers.RequestBuilder(None, {}, "base_url")
 
         # Run
         builder.return_type = str
@@ -35,7 +35,7 @@ class TestRequestBuilder(object):
 
     def test_add_transaction_hook(self, transaction_hook_mock):
         # Setup
-        builder = helpers.RequestBuilder(None, {})
+        builder = helpers.RequestBuilder(None, {}, "base_url")
 
         # Run
         builder.add_transaction_hook(transaction_hook_mock)

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -63,7 +63,7 @@ class RequestPreparer(object):
 
     def create_request_builder(self, definition):
         registry = definition.make_converter_registry(self._converters)
-        return helpers.RequestBuilder(self._client, registry)
+        return helpers.RequestBuilder(self._client, registry, self._base_url)
 
 
 class CallFactory(object):

--- a/uplink/helpers.py
+++ b/uplink/helpers.py
@@ -39,11 +39,12 @@ def set_api_definition(service, name, definition):
 
 
 class RequestBuilder(object):
-    def __init__(self, client, converter_registry):
+    def __init__(self, client, converter_registry, base_url):
         self._method = None
         self._url = None
         self._return_type = None
         self._client = client
+        self._base_url = base_url
 
         # TODO: Pass this in as constructor parameter
         # TODO: Delegate instantiations to uplink.HTTPClientAdapter
@@ -64,6 +65,10 @@ class RequestBuilder(object):
     @method.setter
     def method(self, method):
         self._method = method
+
+    @property
+    def base_url(self):
+        return self._base_url
 
     @property
     def url(self):

--- a/uplink/ratelimit.py
+++ b/uplink/ratelimit.py
@@ -15,8 +15,8 @@ __all__ = ["ratelimit", "RateLimitExceeded"]
 now = time.monotonic if hasattr(time, "monotonic") else time.time
 
 
-def _get_host_and_port(url):
-    parsed_url = utils.urlparse.urlparse(url)
+def _get_host_and_port(base_url):
+    parsed_url = utils.urlparse.urlparse(base_url)
     return parsed_url.hostname, parsed_url.port
 
 
@@ -80,10 +80,10 @@ class ratelimit(decorators.MethodAnnotation):
     defined time period (e.g., 15 calls every 15 minutes).
 
     Note:
-        The limit is enforced separately for each host-port
-        combination. In other words, requests are grouped by host and
-        port, and the number of calls within a time period are counted
-        and capped separately for each group of requests.
+        The rate limit is enforced separately for each host-port
+        combination. Effectively, requests are grouped by host and
+        port, and the number of requests within a time period are
+        counted and capped separately for each group.
 
     By default, when the limit is reached, the client will wait until
     the current period is over before executing any subsequent
@@ -128,7 +128,7 @@ class ratelimit(decorators.MethodAnnotation):
             self._create_limit_reached_exception = None
 
     def _get_limiter_for_request(self, request_builder):
-        key = self._group_by(request_builder.url.build())
+        key = self._group_by(request_builder.base_url)
         try:
             return self._limiter_cache[key]
         except KeyError:

--- a/uplink/ratelimit.py
+++ b/uplink/ratelimit.py
@@ -81,7 +81,9 @@ class ratelimit(decorators.MethodAnnotation):
 
     Note:
         The limit is enforced separately for each host-port
-        combination.
+        combination. In other words, requests are grouped by host and
+        port, and the number of calls within a time period are counted and
+        capped separately for each group of requests.
 
     By default, when the limit is reached, the client will wait until
     the current period is over before executing any subsequent

--- a/uplink/ratelimit.py
+++ b/uplink/ratelimit.py
@@ -82,8 +82,8 @@ class ratelimit(decorators.MethodAnnotation):
     Note:
         The limit is enforced separately for each host-port
         combination. In other words, requests are grouped by host and
-        port, and the number of calls within a time period are counted and
-        capped separately for each group of requests.
+        port, and the number of calls within a time period are counted
+        and capped separately for each group of requests.
 
     By default, when the limit is reached, the client will wait until
     the current period is over before executing any subsequent

--- a/uplink/ratelimit.py
+++ b/uplink/ratelimit.py
@@ -15,6 +15,11 @@ __all__ = ["ratelimit", "RateLimitExceeded"]
 now = time.monotonic if hasattr(time, "monotonic") else time.time
 
 
+def _get_host_and_port(request_builder):
+    parsed_url = utils.urlparse(request_builder.url)
+    return parsed_url.hostname, parsed_url.port
+
+
 class RateLimitExceeded(RuntimeError):
     """A request failed because it exceeded the client-side rate limit."""
 
@@ -32,7 +37,7 @@ class Limiter(object):
         self._max_calls = max_calls
         self._period = period
         self._clock = clock
-        self._lock = threading.RLock()
+        self.__lock = threading.RLock()
         self._reset()
 
     @property
@@ -41,7 +46,7 @@ class Limiter(object):
 
     @contextlib.contextmanager
     def check(self):
-        with self._lock:
+        with self._lock():
             if self.period_remaining <= 0:
                 self._reset()
             yield self._max_calls > self._num_calls
@@ -74,6 +79,10 @@ class ratelimit(decorators.MethodAnnotation):
     consumer to making a specified maximum number of requests within a
     defined time period (e.g., 15 calls every 15 minutes).
 
+    Note:
+        The limit is enforced separately for each host-port
+        combination.
+
     By default, when the limit is reached, the client will wait until
     the current period is over before executing any subsequent
     requests. If you'd prefer the client to raise an exception when the
@@ -89,11 +98,21 @@ class ratelimit(decorators.MethodAnnotation):
             exception is raised.
     """
 
-    def __init__(self, calls=15, period=900, raise_on_limit=False, clock=now):
+    BY_HOST_AND_PORT = _get_host_and_port
+
+    def __init__(
+        self,
+        calls=15,
+        period=900,
+        raise_on_limit=False,
+        group_by=BY_HOST_AND_PORT,
+        clock=now,
+    ):
         self._max_calls = max(1, min(sys.maxsize, math.floor(calls)))
         self._period = period
         self._clock = clock
-        self._limiter = None
+        self._limiter_cache = {}
+        self._group_by = utils.no_op if group_by is None else group_by
 
         if utils.is_subclass(raise_on_limit, Exception) or isinstance(
             raise_on_limit, Exception
@@ -106,10 +125,14 @@ class ratelimit(decorators.MethodAnnotation):
         else:
             self._create_limit_reached_exception = None
 
-    def _get_limiter_for_request(self, _):
-        if self._limiter is None:
-            self._limiter = Limiter(self._max_calls, self._period, self._clock)
-        return self._limiter
+    def _get_limiter_for_request(self, request_builder):
+        key = self._group_by(request_builder.url)
+        try:
+            return self._limiter_cache[key]
+        except KeyError:
+            return self._limiter_cache.setdefault(
+                key, Limiter(self._max_calls, self._period, self._clock)
+            )
 
     def modify_request(self, request_builder):
         limiter = self._get_limiter_for_request(request_builder)

--- a/uplink/ratelimit.py
+++ b/uplink/ratelimit.py
@@ -15,8 +15,8 @@ __all__ = ["ratelimit", "RateLimitExceeded"]
 now = time.monotonic if hasattr(time, "monotonic") else time.time
 
 
-def _get_host_and_port(request_builder):
-    parsed_url = utils.urlparse(request_builder.url)
+def _get_host_and_port(url):
+    parsed_url = utils.urlparse.urlparse(url)
     return parsed_url.hostname, parsed_url.port
 
 
@@ -37,7 +37,7 @@ class Limiter(object):
         self._max_calls = max_calls
         self._period = period
         self._clock = clock
-        self.__lock = threading.RLock()
+        self._lock = threading.RLock()
         self._reset()
 
     @property
@@ -46,7 +46,7 @@ class Limiter(object):
 
     @contextlib.contextmanager
     def check(self):
-        with self._lock():
+        with self._lock:
             if self.period_remaining <= 0:
                 self._reset()
             yield self._max_calls > self._num_calls
@@ -128,7 +128,7 @@ class ratelimit(decorators.MethodAnnotation):
             self._create_limit_reached_exception = None
 
     def _get_limiter_for_request(self, request_builder):
-        key = self._group_by(request_builder.url)
+        key = self._group_by(request_builder.url.build())
         try:
             return self._limiter_cache[key]
         except KeyError:


### PR DESCRIPTION
Proposed Changes:
- The rate limit is enforced separately for each host-port combination. Effectively, requests are grouped by host and port, and the number of requests within a time period are counted and capped separately for each group. 

For example, consider the following consumer:
```python
class GitHub(uplink.Consumer):
    # 1 call every 10 seconds
    @uplink.ratelimit(calls=1, period=10, raise_on_limit=True)
    @uplink.get("repos/{user}/{repo}/issues/{issue}")
    def get_issue(self, user, repo, issue):
        pass
```

These changes prevent two separate instances of the above consumer from blocking each other if the they point to separate hosts:
```python
    # Setup: consumers pointing to separate hosts
    github1 = GitHub(base_url="https://api.github.com", client=mock_client)
    github2 = GitHub(base_url="https://hosted-github-enterprise.com/api", client=mock_client)

    # Run first consumer
    github1.get_issue("prkumar", "uplink", "issue1")

    # Run second consumer: the rate limit should be enforced separately by host-port,
    # so this request should not be rate limited, since the second consumer points to 
    # a different host than the first consumer.
    github2.get_issue("prkumar", "uplink", "issue2")
```