### PR TITLE
Apply class decorators to all consumer methods

### DIFF
--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -145,6 +145,16 @@ class TestMethodAnnotation(object):
         builder = request_definition_builder.method_handler_builder
         assert builder.add_annotation.called
 
+    def test_no_call_on_non_consumer(
+        self, method_annotation, request_definition_builder
+    ):
+        class Class(object):
+            builder = request_definition_builder
+
+        method_annotation(Class)
+        builder = request_definition_builder.method_handler_builder
+        assert not builder.add_annotation.called
+
 
 # TODO: Refactor test cases for method annotations into test case class.
 

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -133,7 +133,7 @@ class TestMethodAnnotation(object):
     def test_call_with_child_class(
         self, method_annotation, request_definition_builder
     ):
-        class Parent(object):
+        class Parent(interfaces.Consumer):
             builder = request_definition_builder
 
         class Child(Parent):

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -139,11 +139,11 @@ class TestMethodAnnotation(object):
         class Child(Parent):
             pass
 
-        # Method annotation should not decorate RequestDefinitionBuilder
-        # attribute of parent class (e.g., `Parent.builder`).
+        # Method annotation should decorate RequestDefinitionBuilder attribute
+        # of parent class (e.g., `Parent.builder`).
         method_annotation(Child)
         builder = request_definition_builder.method_handler_builder
-        assert not builder.add_annotation.called
+        assert builder.add_annotation.called
 
 
 # TODO: Refactor test cases for method annotations into test case class.

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -18,7 +18,8 @@ def test_get_api_definitions_from_parent(request_definition_builder):
         other_builder = request_definition_builder
 
     assert dict(helpers.get_api_definitions(Child)) == {
-        "other_builder": request_definition_builder
+        "builder": request_definition_builder,
+        "other_builder": request_definition_builder,
     }
 
 

--- a/uplink/helpers.py
+++ b/uplink/helpers.py
@@ -13,9 +13,7 @@ def get_api_definitions(service):
     class.
 
     Note:
-        Only attributes defined directly on the class are considered. In
-        other words, inherited `RequestDefinitionBuilder` attributes
-        are ignored.
+        All attributes are considered, not only defined directly on the class.
 
     Args:
         service: A class object.
@@ -28,7 +26,7 @@ def get_api_definitions(service):
     # report in Python issue tracker). Directly invoking `getattr` to
     # force Python's attribute lookup protocol is a decent workaround to
     # ensure parity:
-    class_attributes = ((k, getattr(service, k)) for k in service.__dict__)
+    class_attributes = ((k, getattr(service, k)) for k in dir(service))
 
     is_definition = interfaces.RequestDefinitionBuilder.__instancecheck__
     return [(k, v) for k, v in class_attributes if is_definition(v)]


### PR DESCRIPTION
Fixes #119 .

Changes proposed in this pull request:
- Apply class decorator to all consumer method including inherited
- Effectively revert changes made in #27

Attention: @prkumar