### PR TITLE
Fix bad installations on environments that use ASCII encoding as default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,4 @@ deploy:
   on:
     tags: true
     python: '3.6'
+  distributions: "sdist bdist_wheel"

--- a/README.rst
+++ b/README.rst
@@ -147,7 +147,7 @@ User Testimonials
 
 **Or Carmi** (`@liiight`_), notifiers_ maintainer-
 
-    Uplink’s intelligent usage of decorators and typing leverages the most
+    Uplink's intelligent usage of decorators and typing leverages the most
     pythonic features in an elegant and dynamic way. If you need to create an
     API abstraction layer, there is really no reason to look elsewhere.
 
@@ -164,7 +164,7 @@ Contributing
 ============
 Want to report a bug, request a feature, or contribute code to Uplink?
 Checkout the `Contribution Guide`_ for where to start.
-Thank you for taking the time to improve an open source project 💜
+Thank you for taking the time to improve an open source project :purple_heart:
 
 .. |Build Status| image:: https://travis-ci.org/prkumar/uplink.svg?branch=master
    :target: https://travis-ci.org/prkumar/uplink

--- a/uplink/__about__.py
+++ b/uplink/__about__.py
@@ -3,4 +3,4 @@ This module is the single source of truth for any package metadata
 that is used both in distribution (i.e., setup.py) and within the
 codebase.
 """
-__version__ = "0.8.0.post1"
+__version__ = "0.8.0.post2"


### PR DESCRIPTION
Fixes #148 

Fixed
-----
- Removed non-ASCII characters in README that broke installations on environments where `ascii` 
   encoding is the default.
- Reverted back to deploying a wheel distribution on release