### PR TITLE
Stop sharing class decorators across siblings

### DIFF
--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -167,11 +167,11 @@ def test_setting_request_method(request_definition_builder):
         request_method = request_definition_builder
 
     # Verify: Get request definition builder on access
-    assert Consumer.request_method is request_definition_builder
+    assert Consumer.request_method is request_definition_builder.copy()
 
     # Verify: Try again after resetting
     Consumer.request_method = request_definition_builder
-    assert Consumer.request_method is request_definition_builder
+    assert Consumer.request_method is request_definition_builder.copy()
 
     # Verify: We get callable on attribute access for an instance
     consumer = Consumer()

--- a/uplink/arguments.py
+++ b/uplink/arguments.py
@@ -120,6 +120,9 @@ class ArgumentAnnotationHandlerBuilder(interfaces.AnnotationHandlerBuilder):
     def is_done(self):
         return self.remaining_args_count == 0
 
+    def copy(self):
+        return self
+
     @property
     def _types(self):
         types = self._annotations

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -181,7 +181,7 @@ class ConsumerMethod(object):
 
     def __get__(self, instance, owner):
         if instance is None:
-            return self._request_definition_builder
+            return self._request_definition_builder.copy()
         else:
             return instance.session.create(instance, self._request_definition)
 

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -155,6 +155,14 @@ class RequestDefinitionBuilder(interfaces.RequestDefinitionBuilder):
     def method_handler_builder(self):
         return self._method_handler_builder
 
+    def copy(self):
+        return RequestDefinitionBuilder(
+            self._method,
+            self._uri,
+            self._argument_handler_builder.copy(),
+            self._method_handler_builder.copy(),
+        )
+
     def _auto_fill_remaining_arguments(self):
         uri_vars = set(self.uri.remaining_variables)
         missing = list(self.argument_handler_builder.missing_arguments)

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -95,7 +95,7 @@ class MethodAnnotation(interfaces.Annotation):
         else:
             return is_consumer_class and not (kwargs or args_[1:])
 
-    def __call__(self, class_or_builder, is_class=False):
+    def __call__(self, class_or_builder, **kwargs):
         if self._is_consumer_class(class_or_builder):
             builders = helpers.get_api_definitions(class_or_builder)
             builders = filter(self._is_relevant_for_builder, builders)
@@ -104,7 +104,9 @@ class MethodAnnotation(interfaces.Annotation):
                 self(b, is_class=True)
                 helpers.set_api_definition(class_or_builder, name, b)
         elif isinstance(class_or_builder, interfaces.RequestDefinitionBuilder):
-            class_or_builder.method_handler_builder.add_annotation(self)
+            class_or_builder.method_handler_builder.add_annotation(
+                self, **kwargs
+            )
         return class_or_builder
 
     def modify_request(self, request_builder):

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -37,6 +37,12 @@ class MethodAnnotationHandlerBuilder(interfaces.AnnotationHandlerBuilder):
         super(MethodAnnotationHandlerBuilder, self).add_annotation(annotation)
         return annotation
 
+    def copy(self):
+        clone = MethodAnnotationHandlerBuilder()
+        clone._class_annotations = list(self._class_annotations)
+        clone._method_annotations = list(self._method_annotations)
+        return clone
+
     def build(self):
         return MethodAnnotationHandler(
             self._class_annotations + self._method_annotations
@@ -89,13 +95,13 @@ class MethodAnnotation(interfaces.Annotation):
         else:
             return is_consumer_class and not (kwargs or args_[1:])
 
-    def __call__(self, class_or_builder):
+    def __call__(self, class_or_builder, is_class=False):
         if self._is_consumer_class(class_or_builder):
             builders = helpers.get_api_definitions(class_or_builder)
             builders = filter(self._is_relevant_for_builder, builders)
 
             for name, b in builders:
-                b.method_handler_builder.add_annotation(self, is_class=True)
+                self(b, is_class=True)
                 helpers.set_api_definition(class_or_builder, name, b)
         elif isinstance(class_or_builder, interfaces.RequestDefinitionBuilder):
             class_or_builder.method_handler_builder.add_annotation(self)

--- a/uplink/interfaces.py
+++ b/uplink/interfaces.py
@@ -99,6 +99,9 @@ class RequestDefinitionBuilder(object):
     def build(self):
         raise NotImplementedError
 
+    def copy(self):
+        raise NotImplementedError
+
 
 class RequestDefinition(object):
     def make_converter_registry(self, converters):


### PR DESCRIPTION
I noticed that, when writing a superclass that is extended by two separate subclasses, class-level decorators are shared across the siblings. You can reproduce this issue with the following example:

```python
class GitHub(Consumer):
    @get("users/{id}")
    def get(self, id):
        pass

@response_handler(lambda _: 2)
class GitHub2(GitHub):
    pass


@response_handler(lambda x: x.json())
class GitHub3(GitHub):
    pass


print(GitHub2("https://api.github.com").get_user("prkumar"))
print(GitHub3("https://api.github.com").get_user("prkumar"))
```

Running the above code snippet, you'll notice that the first invocation will throw an `AttributeError` since the response is wrapped by both `lambda _: 2` and `lambda x: x.json()`; notably, the latter handler receives and `int` (i.e., `2`) as it's input, which doesn't have a `json` method.
