### PR TITLE
Refactor @returns.* decorator implementations (#144, #145)

### DIFF
--- a/tests/integration/test_returns.py
+++ b/tests/integration/test_returns.py
@@ -43,7 +43,8 @@ class GitHub(uplink.Consumer):
     def get_repo(self, user, repo):
         pass
 
-    @uplink.returns.from_json(type=uplink.types.List[Repo], key="data")
+    @uplink.returns.from_json(key="data")
+    @uplink.returns.schema(uplink.types.List[Repo])
     @uplink.get("/users/{user}/repos")
     def get_repos(self, user):
         pass

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -209,14 +209,14 @@ class TestRequestDefinition(object):
     def test_argument_annotations(self, annotation_handler_mock):
         annotation_handler_mock.annotations = ["arg1", "arg2"]
         definition = commands.RequestDefinition(
-            None, None, annotation_handler_mock, None
+            None, None, None, annotation_handler_mock, None
         )
         assert list(definition.argument_annotations) == ["arg1", "arg2"]
 
     def test_method_annotations(self, annotation_handler_mock):
         annotation_handler_mock.annotations = ["arg1", "arg2"]
         definition = commands.RequestDefinition(
-            None, None, None, annotation_handler_mock
+            None, None, None, None, annotation_handler_mock
         )
         assert list(definition.method_annotations) == ["arg1", "arg2"]
 
@@ -224,15 +224,20 @@ class TestRequestDefinition(object):
         method = "method"
         uri = "uri"
         definition = commands.RequestDefinition(
-            method, uri, mocker.Mock(), mocker.Mock()
+            method, uri, str, mocker.Mock(), mocker.Mock()
         )
         definition.define_request(request_builder, (), {})
         assert request_builder.method == method
         assert request_builder.url == uri
+        assert request_builder.return_type is str
 
     def test_make_converter_registry(self, annotation_handler_mock):
         definition = commands.RequestDefinition(
-            "method", "uri", annotation_handler_mock, annotation_handler_mock
+            "method",
+            "uri",
+            None,
+            annotation_handler_mock,
+            annotation_handler_mock,
         )
         annotation_handler_mock.annotations = ("annotation",)
         registry = definition.make_converter_registry(())

--- a/tests/unit/test_returns.py
+++ b/tests/unit/test_returns.py
@@ -3,34 +3,70 @@ from uplink import returns
 
 
 def test_returns(request_builder):
-    request_builder.get_converter.return_value = str
     custom = returns(str)
+    request_builder.get_converter.return_value = str
+    request_builder.return_type = returns.ReturnType.with_decorator(
+        None, custom
+    )
     custom.modify_request(request_builder)
-    assert request_builder.return_type.unwrap() is str
+    assert request_builder.return_type(2) == "2"
 
 
-def test_returns_json(request_builder):
+def test_returns_with_multiple_decorators(request_builder, mocker):
+    decorator1 = returns(str)
+    decorator2 = returns.json()
+    request_builder.get_converter.return_value = str
+    first_type = returns.ReturnType.with_decorator(None, decorator1)
+    second_type = (
+        request_builder.return_type
+    ) = returns.ReturnType.with_decorator(
+        first_type, decorator2
+    )
+
+    # Verify that the return type doesn't change after being handled by first decorator
+    decorator1.modify_request(request_builder)
+    assert request_builder.return_type is second_type
+
+    # Verify that the second decorator does handle the return type
+    mock_response = mocker.Mock()
+    mock_response.json.return_value = {"key": "value"}
+    decorator2.modify_request(request_builder)
+    assert request_builder.return_type(mock_response) == str(
+        mock_response.json()
+    )
+
+
+def test_returns_json(request_builder, mocker):
+    mock_response = mocker.Mock()
+    mock_response.json.return_value = {"key": "value"}
     request_builder.get_converter.return_value = str
     returns_json = returns.json(str, ())
+    request_builder.return_type = returns.ReturnType.with_decorator(
+        None, returns_json
+    )
     returns_json.modify_request(request_builder)
-    assert isinstance(request_builder.return_type, returns._StrategyWrapper)
+    assert isinstance(request_builder.return_type, returns.ReturnType)
+    assert callable(request_builder.return_type)
+    assert request_builder.return_type(mock_response) == str(
+        mock_response.json()
+    )
 
     # Verify: Idempotent
     returns_json.modify_request(request_builder)
-    assert isinstance(request_builder.return_type, returns._StrategyWrapper)
-    assert request_builder.return_type.unwrap() is str
+    assert isinstance(request_builder.return_type, returns.ReturnType)
+    assert callable(request_builder.return_type)
+    assert request_builder.return_type(mock_response) == str(
+        mock_response.json()
+    )
 
     # Verify: Doesn't apply to unsupported types
     request_builder.get_converter.return_value = None
-    request_builder.return_type = None
     returns_json = returns.json(str, ())
+    request_builder.return_type = returns.ReturnType.with_decorator(
+        None, returns_json
+    )
     returns_json.modify_request(request_builder)
-    assert request_builder.return_type is None
-
-
-def test_StrategyWrapper():
-    wrapper = returns._StrategyWrapper(None, lambda x: x)
-    assert wrapper("hello") == "hello"
+    assert not callable(request_builder.return_type)
 
 
 def test_returns_JsonStrategy(mocker):

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -132,6 +132,7 @@ class RequestDefinitionBuilder(interfaces.RequestDefinitionBuilder):
         self._uri = uri
         self._argument_handler_builder = argument_handler_builder
         self._method_handler_builder = method_handler_builder
+        self._return_type = None
 
         self._argument_handler_builder.listener = self._notify
         self._method_handler_builder.listener = self._notify
@@ -155,13 +156,23 @@ class RequestDefinitionBuilder(interfaces.RequestDefinitionBuilder):
     def method_handler_builder(self):
         return self._method_handler_builder
 
+    @property
+    def return_type(self):
+        return self._return_type
+
+    @return_type.setter
+    def return_type(self, return_type):
+        self._return_type = return_type
+
     def copy(self):
-        return RequestDefinitionBuilder(
+        builder = RequestDefinitionBuilder(
             self._method,
             self._uri,
             self._argument_handler_builder.copy(),
             self._method_handler_builder.copy(),
         )
+        builder.return_type = self.return_type
+        return builder
 
     def _auto_fill_remaining_arguments(self):
         uri_vars = set(self.uri.remaining_variables)
@@ -184,14 +195,21 @@ class RequestDefinitionBuilder(interfaces.RequestDefinitionBuilder):
         method_handler = self._method_handler_builder.build()
         uri = self._uri.build()
         return RequestDefinition(
-            self._method, uri, argument_handler, method_handler
+            self._method,
+            uri,
+            self._return_type,
+            argument_handler,
+            method_handler,
         )
 
 
 class RequestDefinition(interfaces.RequestDefinition):
-    def __init__(self, method, uri, argument_handler, method_handler):
+    def __init__(
+        self, method, uri, return_type, argument_handler, method_handler
+    ):
         self._method = method
         self._uri = uri
+        self._return_type = return_type
         self._argument_handler = argument_handler
         self._method_handler = method_handler
 
@@ -209,6 +227,7 @@ class RequestDefinition(interfaces.RequestDefinition):
     def define_request(self, request_builder, func_args, func_kwargs):
         request_builder.method = self._method
         request_builder.url = utils.URIBuilder(self._uri)
+        request_builder.return_type = self._return_type
         self._argument_handler.handle_call(
             request_builder, func_args, func_kwargs
         )

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -95,6 +95,9 @@ class MethodAnnotation(interfaces.Annotation):
         else:
             return is_consumer_class and not (kwargs or args_[1:])
 
+    def _modify_request_definition(self, builder, kwargs):
+        builder.method_handler_builder.add_annotation(self, **kwargs)
+
     def __call__(self, class_or_builder, **kwargs):
         if self._is_consumer_class(class_or_builder):
             builders = helpers.get_api_definitions(class_or_builder)
@@ -104,9 +107,7 @@ class MethodAnnotation(interfaces.Annotation):
                 self(b, is_class=True)
                 helpers.set_api_definition(class_or_builder, name, b)
         elif isinstance(class_or_builder, interfaces.RequestDefinitionBuilder):
-            class_or_builder.method_handler_builder.add_annotation(
-                self, **kwargs
-            )
+            self._modify_request_definition(class_or_builder, kwargs)
         return class_or_builder
 
     def modify_request(self, request_builder):


### PR DESCRIPTION
Fixes #144 and #145.

Changes proposed in this pull request:
- Allow a `@returns.*` decorator to override a consumer method's return annotation as the assigned schema used for deserialization (#144)
- Properly cascade `@returns.*` decorators when used as class decorators (#145)