### PR TITLE
Add `Context` argument annotation

### DIFF
--- a/docs/source/dev/types.rst
+++ b/docs/source/dev/types.rst
@@ -67,3 +67,8 @@ Timeout
 =======
 
 .. autoclass:: uplink.Timeout
+
+Context
+=======
+
+.. autoclass:: uplink.Context

--- a/tests/integration/test_handlers.py
+++ b/tests/integration/test_handlers.py
@@ -108,7 +108,7 @@ def test_error_handler_with_consumer(mock_client):
         assert err.exception == expected_error
         assert calendar.flagged is True
     else:
-        assert False
+        raise AssertionError
 
 
 def test_error_handler(mock_client):

--- a/tests/integration/test_handlers.py
+++ b/tests/integration/test_handlers.py
@@ -124,4 +124,4 @@ def test_error_handler(mock_client):
     except WrappedException as err:
         assert err.exception == expected_error
     else:
-        assert False
+        raise AssertionError

--- a/tests/integration/test_handlers.py
+++ b/tests/integration/test_handlers.py
@@ -35,22 +35,28 @@ def handle_error(exc_type, exc_value, exc_tb):
 
 class Calendar(uplink.Consumer):
     @handle_response_with_consumer
-    @uplink.get("/calendar/{todo_id}")
+    @uplink.get("todos/{todo_id}")
     def get_todo(self, todo_id):
         pass
 
     @handle_response
-    @uplink.get("/calendar/{name}")
+    @uplink.get("months/{name}/todos")
     def get_month(self, name):
         pass
 
+    @handle_response_with_consumer
+    @handle_response
+    @uplink.get("months/{month}/days/{day}/todos")
+    def get_day(self, month, day):
+        pass
+
     @handle_error_with_consumer
-    @uplink.get("/calendar/{user_id}")
+    @uplink.get("users/{user_id}")
     def get_user(self, user_id):
         pass
 
     @handle_error
-    @uplink.get("/calendar/{event_id}")
+    @uplink.get("events/{event_id}")
     def get_event(self, event_id):
         pass
 
@@ -74,6 +80,17 @@ def test_response_handler(mock_client):
 
     # Verify
     assert response.flagged is True
+
+
+def test_multiple_response_handlers(mock_client):
+    calendar = Calendar(base_url=BASE_URL, client=mock_client)
+
+    # Run
+    response = calendar.get_day("September", 2)
+
+    # Verify
+    assert response.flagged
+    assert calendar.flagged
 
 
 def test_error_handler_with_consumer(mock_client):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,12 +16,6 @@ def http_client_mock(mocker):
 
 
 @pytest.fixture
-def request_mock(mocker):
-    # TODO: Remove
-    return None
-
-
-@pytest.fixture
 def transaction_hook_mock(mocker):
     return mocker.Mock(spec=hooks.TransactionHook)
 
@@ -70,6 +64,7 @@ def uplink_builder_mock(mocker):
 def request_builder(mocker):
     builder = mocker.MagicMock(spec=helpers.RequestBuilder)
     builder.info = collections.defaultdict(dict)
+    builder.context = {}
     builder.get_converter.return_value = lambda x: x
     builder.client.exceptions = Exceptions()
     return builder

--- a/tests/unit/test_arguments.py
+++ b/tests/unit/test_arguments.py
@@ -440,3 +440,16 @@ class TestContext(ArgumentTestCase, FuncDecoratorTestCase):
     def test_modify_request(self, request_builder):
         arguments.Context("key").modify_request(request_builder, "value")
         assert request_builder.context["key"] == "value"
+
+
+class TestContextMap(ArgumentTestCase, FuncDecoratorTestCase):
+    type_cls = arguments.ContextMap
+    expected_converter_key = keys.Identity()
+
+    def test_modify_request(self, request_builder):
+        arguments.ContextMap().modify_request(request_builder, {"key": "value"})
+        assert request_builder.context == {"key": "value"}
+
+    def test_modify_request_not_mapping(self, request_builder):
+        with pytest.raises(TypeError):
+            arguments.ContextMap().modify_request(request_builder, "value")

--- a/tests/unit/test_arguments.py
+++ b/tests/unit/test_arguments.py
@@ -276,9 +276,7 @@ class TestQuery(ArgumentTestCase, FuncDecoratorTestCase):
             )
 
     def test_skip_none(self, request_builder):
-        arguments.Query("name").modify_request(
-            request_builder, None
-        )
+        arguments.Query("name").modify_request(request_builder, None)
         assert request_builder.info["params"] == {}
 
     def test_encode_none(self, request_builder):
@@ -433,3 +431,12 @@ class TestTimeout(ArgumentTestCase, FuncDecoratorTestCase):
     def test_modify_request(self, request_builder):
         arguments.Timeout().modify_request(request_builder, 10)
         assert request_builder.info["timeout"] == 10
+
+
+class TestContext(ArgumentTestCase, FuncDecoratorTestCase):
+    type_cls = arguments.Context
+    expected_converter_key = keys.Identity()
+
+    def test_modify_request(self, request_builder):
+        arguments.Context("key").modify_request(request_builder, "value")
+        assert request_builder.context["key"] == "value"

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -48,7 +48,7 @@ class TestRequestPreparer(object):
         request_builder.url = "/example/path"
         request_builder.request_template = "request_template"
         uplink_builder.base_url = "https://example.com"
-        uplink_builder.add_hook(transaction_hook_mock)
+        request_builder.transaction_hooks = [transaction_hook_mock]
         request_preparer = builder.RequestPreparer(uplink_builder)
         execution_builder = mocker.Mock(spec=io.RequestExecutionBuilder)
         request_preparer.prepare_request(request_builder, execution_builder)
@@ -61,10 +61,25 @@ class TestRequestPreparer(object):
         execution_builder.with_io.assert_called_with(uplink_builder.client.io())
         execution_builder.with_template(request_builder.request_template)
 
-    def test_create_request_builder(self, uplink_builder, request_definition):
+    def test_create_request_builder(self, mocker, request_definition):
+        uplink_builder = mocker.Mock(spec=builder.Builder)
+        uplink_builder.converters = ()
+        uplink_builder.hooks = ()
         request_definition.make_converter_registry.return_value = {}
         request_preparer = builder.RequestPreparer(uplink_builder)
         request = request_preparer.create_request_builder(request_definition)
+        assert isinstance(request, helpers.RequestBuilder)
+
+    def test_create_request_builder_with_session_hooks(
+        self, mocker, request_definition, transaction_hook_mock
+    ):
+        uplink_builder = mocker.Mock(spec=builder.Builder)
+        uplink_builder.converters = ()
+        uplink_builder.hooks = (transaction_hook_mock,)
+        request_definition.make_converter_registry.return_value = {}
+        request_preparer = builder.RequestPreparer(uplink_builder)
+        request = request_preparer.create_request_builder(request_definition)
+        assert transaction_hook_mock.audit_request.called
         assert isinstance(request, helpers.RequestBuilder)
 
 

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -43,3 +43,13 @@ class TestRequestBuilder(object):
 
         # Verify
         assert list(builder.transaction_hooks) == [transaction_hook_mock]
+
+    def test_context(self):
+        # Setup
+        builder = helpers.RequestBuilder(None, {}, "base_url")
+
+        # Run
+        builder.context["key"] = "value"
+
+        # Verify
+        assert builder.context["key"] == "value"

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -53,3 +53,15 @@ def test_auth_set(uplink_builder_mock):
 
     # Verify
     assert ("username", "password") == uplink_builder_mock.auth
+
+
+def test_context(uplink_builder_mock):
+    # Setup
+    sess = session.Session(uplink_builder_mock)
+
+    # Run
+    sess.context["key"] = "value"
+
+    # Verify
+    assert uplink_builder_mock.add_hook.called
+    assert sess.context == {"key": "value"}

--- a/uplink/__init__.py
+++ b/uplink/__init__.py
@@ -41,6 +41,7 @@ from uplink.arguments import (
     Body,
     Url,
     Timeout,
+    Context,
 )
 from uplink.ratelimit import ratelimit
 from uplink.retry import retry
@@ -90,6 +91,7 @@ __all__ = [
     "Body",
     "Url",
     "Timeout",
+    "Context",
     "retry",
     "ratelimit",
 ]

--- a/uplink/arguments.py
+++ b/uplink/arguments.py
@@ -750,11 +750,12 @@ class Context(FuncDecoratorMixin, NamedArgument):
 
         To add a name-value pair to the context of any request made from
         a :class:`Consumer <uplink.Consumer>` instance, you
-        can use the :attr:`Consumer.session.context <uplink.session.Session.context>`
-        property. Alternatively, you can annotate a constructor argument of a
-        :class:`Consumer <uplink.Consumer>` subclass with :class:`Context <uplink.Context>`, as explained
+        can use the :attr:`Consumer.session.context
+        <uplink.session.Session.context>` property. Alternatively, you
+        can annotate a constructor argument of a :class:`Consumer
+        <uplink.Consumer>` subclass with :class:`Context
+        <uplink.Context>`, as explained
         :ref:`here <annotating constructor arguments>`.
-
     """
 
     @property

--- a/uplink/arguments.py
+++ b/uplink/arguments.py
@@ -683,7 +683,7 @@ class Url(ArgumentAnnotation):
 
 class Timeout(FuncDecoratorMixin, ArgumentAnnotation):
     """
-    Pass a timeout as a method argument at runtime.
+    Passes a timeout as a method argument at runtime.
 
     While :py:class:`uplink.timeout` attaches static timeout to all requests
     sent from a consumer method, this class turns a method argument into a
@@ -696,7 +696,6 @@ class Timeout(FuncDecoratorMixin, ArgumentAnnotation):
             def get_posts(self, timeout: Timeout() = 60):
                 \"""Fetch all posts for the current users giving up after given
                 number of seconds.\"""
-
     """
 
     @property
@@ -711,3 +710,17 @@ class Timeout(FuncDecoratorMixin, ArgumentAnnotation):
     def _modify_request(self, request_builder, value):
         """Modifies request timeout."""
         request_builder.info["timeout"] = value
+
+
+class Context(FuncDecoratorMixin, NamedArgument):
+    """
+    Adds a name-value pair to the request context. The value at runtime
+    is accessible to decorators and other middleware.
+    """
+
+    @property
+    def converter_key(self):
+        return keys.Identity()
+
+    def _modify_request(self, request_builder, value):
+        request_builder.context[self.name] = value

--- a/uplink/arguments.py
+++ b/uplink/arguments.py
@@ -24,6 +24,7 @@ __all__ = [
     "Body",
     "Url",
     "Timeout",
+    "Context",
 ]
 
 

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -22,41 +22,55 @@ __all__ = ["build", "Consumer"]
 
 class RequestPreparer(object):
     def __init__(self, builder, consumer=None):
-        self._hooks = list(builder.hooks)
         self._client = builder.client
         self._base_url = str(builder.base_url)
         self._converters = list(builder.converters)
         self._auth = builder.auth
         self._consumer = consumer
 
+        if builder.hooks:
+            self._session_chain = hooks_.TransactionHookChain(*builder.hooks)
+        else:
+            self._session_chain = None
+
     def _join_url_with_base(self, url):
         return utils.urlparse.urljoin(self._base_url, url)
 
-    def _get_hook_chain(self, contract):
+    @staticmethod
+    def _get_request_hooks(contract):
         chain = list(contract.transaction_hooks)
         if callable(contract.return_type):
             chain.append(hooks_.ResponseHandler(contract.return_type))
-        chain.extend(self._hooks)
         return chain
 
     def _wrap_hook(self, func):
         return functools.partial(func, self._consumer)
 
-    def apply_hooks(self, execution_builder, chain, request_builder):
-        hook = hooks_.TransactionHookChain(*chain)
-        hook.audit_request(self._consumer, request_builder)
-        if hook.handle_response is not None:
+    def apply_hooks(self, execution_builder, chain):
+        # TODO:
+        #   Instead of creating a TransactionChain, we could simply
+        #   add each response and error handler in the chain to the
+        #   execution builder. This would allow heterogenous response
+        #   and error handlers. Right now, the TransactionChain
+        #   enforces that all response/error handlers are blocking if
+        #   any response/error handler is blocking, which is
+        #   unnecessary now that we delegate execution to an IO layer.
+        if chain.handle_response is not None:
             execution_builder.with_callbacks(
-                self._wrap_hook(hook.handle_response)
+                self._wrap_hook(chain.handle_response)
             )
-        execution_builder.with_errbacks(self._wrap_hook(hook.handle_exception))
+        execution_builder.with_errbacks(self._wrap_hook(chain.handle_exception))
 
     def prepare_request(self, request_builder, execution_builder):
         request_builder.url = self._join_url_with_base(request_builder.url)
         self._auth(request_builder)
-        chain = self._get_hook_chain(request_builder)
-        if chain:
-            self.apply_hooks(execution_builder, chain, request_builder)
+        request_hooks = self._get_request_hooks(request_builder)
+        if request_hooks:
+            chain = hooks_.TransactionHookChain(*request_hooks)
+            chain.audit_request(self._consumer, request_builder)
+            self.apply_hooks(execution_builder, chain)
+        if self._session_chain:
+            self.apply_hooks(execution_builder, self._session_chain)
 
         execution_builder.with_client(self._client)
         execution_builder.with_io(self._client.io())
@@ -64,7 +78,10 @@ class RequestPreparer(object):
 
     def create_request_builder(self, definition):
         registry = definition.make_converter_registry(self._converters)
-        return helpers.RequestBuilder(self._client, registry, self._base_url)
+        req = helpers.RequestBuilder(self._client, registry, self._base_url)
+        if self._session_chain:
+            self._session_chain.audit_request(self._consumer, req)
+        return req
 
 
 class CallFactory(object):

--- a/uplink/clients/io/execution.py
+++ b/uplink/clients/io/execution.py
@@ -26,11 +26,11 @@ class RequestExecutionBuilder(object):
         return self
 
     def with_callbacks(self, *callbacks):
-        self._callbacks = list(callbacks)
+        self._callbacks.extend(callbacks)
         return self
 
     def with_errbacks(self, *errbacks):
-        self._errbacks = list(errbacks)
+        self._errbacks.extend(errbacks)
         return self
 
     def build(self):

--- a/uplink/helpers.py
+++ b/uplink/helpers.py
@@ -47,6 +47,7 @@ class RequestBuilder(object):
         # TODO: Pass this in as constructor parameter
         # TODO: Delegate instantiations to uplink.HTTPClientAdapter
         self._info = collections.defaultdict(dict)
+        self._context = {}
 
         self._converter_registry = converter_registry
         self._transaction_hooks = []
@@ -79,6 +80,10 @@ class RequestBuilder(object):
     @property
     def info(self):
         return self._info
+
+    @property
+    def context(self):
+        return self._context
 
     @property
     def transaction_hooks(self):

--- a/uplink/session.py
+++ b/uplink/session.py
@@ -15,6 +15,7 @@ class Session(object):
         self.__builder = builder
         self.__params = None
         self.__headers = None
+        self.__context = None
 
     def create(self, consumer, definition):
         return self.__builder.build(definition, consumer)
@@ -47,6 +48,17 @@ class Session(object):
             self.__params = {}
             self.inject(arguments.QueryMap().with_value(self.__params))
         return self.__params
+
+    @property
+    def context(self):
+        """
+        A dictionary of name-value pairs that are made available to
+        request middleware.
+        """
+        if self.__context is None:
+            self.__context = {}
+            self.inject(arguments.ContextMap().with_value(self.__context))
+        return self.__context
 
     @property
     def auth(self):


### PR DESCRIPTION
Fixes #143.

The `Context` annotation can be used to pass data to middleware implemented as a `MethodAnnotation`, like the `cache` decorator that @kaidokert proposed on [gitter](https://gitter.im/python-uplink/Lobby?at=5c69f8e5dc3f0523ccd21e5a).

Attention: @prkumar