### PR TITLE
Extend Consumer Methods to Reduce Boilerplate

### DIFF
--- a/docs/source/user/quickstart.rst
+++ b/docs/source/user/quickstart.rst
@@ -51,6 +51,8 @@ So far, this class looks like any other Python class. The real magic
 happens when you define methods to interact with the webservice using
 Uplink's HTTP method decorators, which we cover next.
 
+.. _making-a-request:
+
 Making a Request
 ================
 

--- a/docs/source/user/tips.rst
+++ b/docs/source/user/tips.rst
@@ -250,9 +250,9 @@ class:
         @get_user_repos
         def get_team_repos_for_user(self, user):
             """
-             Retrieves the repos that are owned by teams
-             that the user holds membership in.
-             """
+            Retrieves the repos that are owned by teams
+            that the user holds membership in.
+            """
 
     class EnhancedGitHub(Github):
         # Updates the return type of an inherited method.

--- a/docs/source/user/tips.rst
+++ b/docs/source/user/tips.rst
@@ -198,3 +198,64 @@ calculate request properties within plain old python methods.
 Similar to the annotation style, request properties added with
 :py:meth:`~uplink.Consumer._inject` method are applied to all requests made
 through the consumer instance.
+
+
+Extend Consumer Methods to Reduce Boilerplate
+=============================================
+
+.. versionadded:: v0.9.0
+
+**Consumer methods** are methods decorated with Uplink's HTTP method decorators,
+such as :class:`@get <uplink.get>` or :class:`@post <uplink.post>` (see
+:ref:`here <making-a-request>` for more background).
+
+Consumer methods can be used as decorators to minimize duplication across similar
+consumer method definitions.
+
+For example, you can define consumer method templates like so:
+
+.. code-block:: python
+   :emphasize-lines: 6-7,10
+
+    from uplink import Consumer, get, json
+
+    @returns.json
+    @json
+    @get
+    def get_json():
+        """Template for GET request that consumes and produces JSON."""
+
+    class GitHub(Consumer):
+        @get_json("/users/{user}")
+        def get_user(self, user):
+             """Fetches a specific GitHub user."""
+
+Further, you can use this technique to remove duplication across definitions
+of similar consumer methods, whether or not the methods are defined in the same
+class:
+
+.. code-block:: python
+   :emphasize-lines: 9-11,19-20
+
+    from uplink import Consumer, get, params, timeout
+
+    class GitHub(Consumer):
+        @timeout(10)
+        @get("/users/{user}/repos")
+        def get_user_repos(self, user):
+            """Retrieves the repos that the user owns."""
+
+        # Extends the above method to define a variant:
+        @params(type="member")
+        @get_user_repos
+        def get_team_repos_for_user(self, user):
+            """
+             Retrieves the repos that are owned by teams
+             that the user holds membership in.
+             """
+
+    class EnhancedGitHub(Github):
+        # Updates the return type of an inherited method.
+        @GitHub.get_user_repos
+        def get_user_repos(self, user) -> List[Repo]:
+            """Retrieves the repos that the user owns."""

--- a/docs/source/user/tips.rst
+++ b/docs/source/user/tips.rst
@@ -217,7 +217,7 @@ For example, you can define consumer method templates like so:
 .. code-block:: python
    :emphasize-lines: 6-7,10
 
-    from uplink import Consumer, get, json
+    from uplink import Consumer, get, json, returns
 
     @returns.json
     @json
@@ -248,10 +248,10 @@ class:
         # Extends the above method to define a variant:
         @params(type="member")
         @get_user_repos
-        def get_team_repos_for_user(self, user):
+        def get_repos_for_collaborator(self, user):
             """
-            Retrieves the repos that are owned by teams
-            that the user holds membership in.
+            Retrieves the repos for which the given user is
+            a collaborator.
             """
 
     class EnhancedGitHub(Github):

--- a/tests/integration/test_extend.py
+++ b/tests/integration/test_extend.py
@@ -1,0 +1,94 @@
+# Third-party imports
+import pytest
+
+# Local imports
+import uplink
+
+# Constants
+BASE_URL = "https://api.github.com"
+
+
+class GitHubError(Exception):
+    pass
+
+
+@uplink.response_handler
+def github_error(response):
+    if "errors" in response.json():
+        raise GitHubError()
+    return response
+
+
+@uplink.timeout(10)
+class GitHubService(uplink.Consumer):
+    @github_error
+    @uplink.json
+    @uplink.post("graphql", args=(uplink.Body,))
+    def graphql(self, **body: uplink.Body):
+        pass
+
+    @uplink.returns.json(member=("data", "repository"))
+    @uplink.args(body=uplink.Body)
+    @graphql
+    def get_repository(self, **body):
+        pass
+
+    @uplink.returns.json(member=("data", "repository"))
+    @graphql.extend("graphql2", args=(uplink.Body,))
+    def get_repository2(self, **body):
+        pass
+
+
+def test_get_repository(mock_client, mock_response):
+    data = {
+        "query": """\
+query {
+    repository(owner: "prkumar", name: "uplink") {
+        nameWithOwner
+    }
+}"""
+    }
+    result = {"data": {"repository": {"nameWithOwner": "prkumar/uplink"}}}
+    mock_response.with_json(result)
+    mock_client.with_response(mock_response)
+    github = GitHubService(base_url=BASE_URL, client=mock_client)
+    response = github.get_repository(**data)
+    request = mock_client.history[0]
+    assert request.method == "POST"
+    assert request.base_url == BASE_URL
+    assert request.endpoint == "/graphql"
+    assert request.timeout == 10
+    assert request.json == data
+    assert response == result["data"]["repository"]
+
+
+def test_get_repository2_failure(mock_client, mock_response):
+    data = {
+        "query": """\
+query {
+    repository(owner: "prkumar", name: "uplink") {
+        nameWithOwner
+    }
+}"""
+    }
+    result = {
+        "data": {"repository": None},
+        "errors": [
+            {
+                "type": "NOT_FOUND",
+                "path": ["repository"],
+                "locations": [{"line": 7, "column": 3}],
+                "message": "Could not resolve to a User with the username 'prkussmar'.",
+            }
+        ],
+    }
+    mock_response.with_json(result)
+    mock_client.with_response(mock_response)
+    github = GitHubService(base_url=BASE_URL, client=mock_client)
+    with pytest.raises(GitHubError):
+        github.get_repository2(**data)
+    request = mock_client.history[0]
+    assert request.method == "POST"
+    assert request.base_url == BASE_URL
+    assert request.endpoint == "/graphql2"
+    assert request.timeout == 10

--- a/tests/integration/test_extend.py
+++ b/tests/integration/test_extend.py
@@ -24,7 +24,7 @@ class GitHubService(uplink.Consumer):
     @github_error
     @uplink.json
     @uplink.post("graphql", args=(uplink.Body,))
-    def graphql(self, **body: uplink.Body):
+    def graphql(self, **body):
         pass
 
     @uplink.returns.json(member=("data", "repository"))

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -228,7 +228,7 @@ class RequestDefinitionBuilder(interfaces.RequestDefinitionBuilder):
                         \"""
                          Retrieves the repos that are owned by teams
                          that the user holds membership in.
-                         \"""
+                        \"""
 
                 class EnhancedGitHub(Github):
                     # Updates the return type of an inherited method.

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -160,11 +160,11 @@ class headers(_BaseRequestProperties):
         **kwargs: More header values.
     """
 
-    def __init__(self, arg, **kwargs):
+    def __init__(self, arg=None, **kwargs):
         if isinstance(arg, str):
             key, value = self._split(arg)
             arg = {key: value}
-        super(headers, self).__init__(arg, **kwargs)
+        super(headers, self).__init__(arg or {}, **kwargs)
 
     @property
     def _delimiter(self):
@@ -203,10 +203,10 @@ class params(_BaseRequestProperties):
         **kwargs: More query parameters.
     """
 
-    def __init__(self, arg, **kwargs):
+    def __init__(self, arg=None, **kwargs):
         if isinstance(arg, str):
             arg = arg.split("&")
-        super(params, self).__init__(arg, **kwargs)
+        super(params, self).__init__(arg or {}, **kwargs)
 
     @property
     def _property_name(self):


### PR DESCRIPTION
Fixes #151

**Consumer methods** are methods decorated with Uplink's HTTP method decorators,
such as `@get` or `@post` (see
[here](https://uplink.readthedocs.io/en/latest/user/quickstart.html#making-a-request) for more background).

Consumer methods can be used as decorators to minimize duplication across similar
consumer method definitions.

For example, you can define consumer method templates like so:

```python
from uplink import Consumer, get, json

@returns.json
@json
@get
def get_json():
     """Template for GET request that consumes and produces JSON."""

class GitHub(Consumer):
    @get_json("/users/{user}")
    def get_user(self, user):
        """Fetches a specific GitHub user."""
```

Further, you can use this technique to remove duplication across definitions
of similar consumer methods, whether or not the methods are defined in the same
class:

```python
from uplink import Consumer, get, params, timeout

class GitHub(Consumer):
    @timeout(10)
    @get("/users/{user}/repos")
    def get_user_repos(self, user):
        """Retrieves the repos that the user owns."""

    # Extends the above method to define a variant:
    @params(type="member")
    @get_user_repos
    def get_team_repos_for_user(self, user):
        """
        Retrieves the repos that are owned by teams
        that the user holds membership in.
        """

class EnhancedGitHub(Github):
    # Updates the return type of an inherited method.
    @GitHub.get_user_repos
    def get_user_repos(self, user) -> List[Repo]:
        """Retrieves the repos that the user owns."""
```

CC: @liiight