### PR TITLE
Fix uplink.Url by checking url type (fixes #164)

### DIFF
--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -21,6 +21,10 @@ class GitHubService(uplink.Consumer):
     def get_repo(self, user, repo):
         pass
 
+    @uplink.get(args={"url": uplink.Url})
+    def forward(self, url):
+        pass
+
 
 def test_list_repo(mock_client):
     github = GitHubService(base_url=BASE_URL, client=mock_client)
@@ -49,6 +53,15 @@ def test_get_repo(mock_client, mock_response):
 
     # Verify
     assert expected_json == actual_json
+
+
+def test_forward(mock_client):
+    github = GitHubService(base_url=BASE_URL, client=mock_client)
+    github.forward("/users/prkumar/repos")
+    request = mock_client.history[0]
+    assert request.method == "GET"
+    assert request.has_base_url(BASE_URL)
+    assert request.has_endpoint("/users/prkumar/repos")
 
 
 def test_handle_client_exceptions(mock_client):

--- a/tests/unit/test_arguments.py
+++ b/tests/unit/test_arguments.py
@@ -249,7 +249,7 @@ class TestPath(ArgumentTestCase):
 
     def test_modify_request(self, request_builder):
         arguments.Path("name").modify_request(request_builder, "value")
-        request_builder.url.set_variable.assert_called_with({"name": "value"})
+        request_builder.set_url_variable.assert_called_with({"name": "value"})
 
 
 class TestQuery(ArgumentTestCase, FuncDecoratorTestCase):
@@ -421,7 +421,7 @@ class TestUrl(ArgumentTestCase):
 
     def test_modify_request(self, request_builder):
         arguments.Url().modify_request(request_builder, "/some/path")
-        assert request_builder.url == "/some/path"
+        assert request_builder.relative_url == "/some/path"
 
 
 class TestTimeout(ArgumentTestCase, FuncDecoratorTestCase):

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -25,7 +25,7 @@ def uplink_builder(http_client_mock):
 class TestRequestPreparer(object):
     def test_prepare_request(self, mocker, request_builder):
         request_builder.method = "METHOD"
-        request_builder.url = "/example/path"
+        request_builder.relative_url = "/example/path"
         request_builder.return_type = None
         request_builder.transaction_hooks = ()
         request_builder.request_template = "request_template"
@@ -45,7 +45,7 @@ class TestRequestPreparer(object):
         self, mocker, uplink_builder, request_builder, transaction_hook_mock
     ):
         request_builder.method = "METHOD"
-        request_builder.url = "/example/path"
+        request_builder.relative_url = "/example/path"
         request_builder.request_template = "request_template"
         uplink_builder.base_url = "https://example.com"
         request_builder.transaction_hooks = [transaction_hook_mock]
@@ -105,7 +105,11 @@ class TestCallFactory(object):
             request_builder, execution_builder
         )
         execution_builder.build().start.assert_called_with(
-            (request_builder.method, request_builder.url, request_builder.info)
+            (
+                request_builder.method,
+                request_builder.relative_url,
+                request_builder.info,
+            )
         )
 
 

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -105,11 +105,7 @@ class TestCallFactory(object):
             request_builder, execution_builder
         )
         execution_builder.build().start.assert_called_with(
-            (
-                request_builder.method,
-                request_builder.relative_url,
-                request_builder.info,
-            )
+            (request_builder.method, request_builder.url, request_builder.info)
         )
 
 

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -228,7 +228,7 @@ class TestRequestDefinition(object):
         )
         definition.define_request(request_builder, (), {})
         assert request_builder.method == method
-        assert request_builder.url == uri
+        assert request_builder.relative_url == uri
         assert request_builder.return_type is str
 
     def test_make_converter_registry(self, annotation_handler_mock):

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,3 +1,6 @@
+import pytest
+
+# Local imports
 from uplink import helpers
 
 
@@ -53,3 +56,22 @@ class TestRequestBuilder(object):
 
         # Verify
         assert builder.context["key"] == "value"
+
+    def test_relative_url_template(self):
+        # Setup
+        builder = helpers.RequestBuilder(None, {}, "base_url")
+
+        # Run
+        builder.relative_url = "/v1/api/users/{username}/repos"
+        builder.set_url_variable({"username": "cognifloyd"})
+
+        # Verify
+        assert builder.relative_url == "/v1/api/users/cognifloyd/repos"
+
+    def test_relative_url_template_type_error(self):
+        # Setup
+        builder = helpers.RequestBuilder(None, {}, "base_url")
+
+        # Run
+        with pytest.raises(TypeError):
+            builder.relative_url = 1

--- a/uplink/arguments.py
+++ b/uplink/arguments.py
@@ -301,7 +301,7 @@ class Path(NamedArgument):
         request_definition_builder.uri.add_variable(self.name)
 
     def _modify_request(self, request_builder, value):
-        request_builder.url.set_variable({self.name: value})
+        request_builder.set_url_variable({self.name: value})
 
 
 class Query(FuncDecoratorMixin, NamedArgument):
@@ -680,7 +680,7 @@ class Url(ArgumentAnnotation):
     @classmethod
     def _modify_request(cls, request_builder, value):
         """Updates request url."""
-        request_builder.url = utils.URIBuilder(value)
+        request_builder.relative_url = value
 
 
 class Timeout(FuncDecoratorMixin, ArgumentAnnotation):

--- a/uplink/arguments.py
+++ b/uplink/arguments.py
@@ -639,6 +639,7 @@ class Body(TypedArgument):
         request_builder.info["data"] = value
 
 
+# TODO: Add an integration test that uses arguments.Url
 class Url(ArgumentAnnotation):
     """
     Sets a dynamic URL.
@@ -679,7 +680,7 @@ class Url(ArgumentAnnotation):
     @classmethod
     def _modify_request(cls, request_builder, value):
         """Updates request url."""
-        request_builder.url = value
+        request_builder.url = utils.URIBuilder(value)
 
 
 class Timeout(FuncDecoratorMixin, ArgumentAnnotation):

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -62,7 +62,9 @@ class RequestPreparer(object):
         execution_builder.with_errbacks(self._wrap_hook(chain.handle_exception))
 
     def prepare_request(self, request_builder, execution_builder):
-        request_builder.url = self._join_url_with_base(request_builder.url)
+        request_builder.relative_url = self._join_url_with_base(
+            request_builder.relative_url
+        )
         self._auth(request_builder)
         request_hooks = self._get_request_hooks(request_builder)
         if request_hooks:
@@ -104,7 +106,11 @@ class CallFactory(object):
         execution = execution_builder.build()
         return execution.start(
             # TODO: Create request value object
-            (request_builder.method, request_builder.url, request_builder.info)
+            (
+                request_builder.method,
+                request_builder.relative_url,
+                request_builder.info,
+            )
         )
 
 

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -33,9 +33,6 @@ class RequestPreparer(object):
         else:
             self._session_chain = None
 
-    def _join_url_with_base(self, url):
-        return utils.urlparse.urljoin(self._base_url, url)
-
     @staticmethod
     def _get_request_hooks(contract):
         chain = list(contract.transaction_hooks)
@@ -62,9 +59,6 @@ class RequestPreparer(object):
         execution_builder.with_errbacks(self._wrap_hook(chain.handle_exception))
 
     def prepare_request(self, request_builder, execution_builder):
-        request_builder.relative_url = self._join_url_with_base(
-            request_builder.relative_url
-        )
         self._auth(request_builder)
         request_hooks = self._get_request_hooks(request_builder)
         if request_hooks:
@@ -106,11 +100,7 @@ class CallFactory(object):
         execution = execution_builder.build()
         return execution.start(
             # TODO: Create request value object
-            (
-                request_builder.method,
-                request_builder.relative_url,
-                request_builder.info,
-            )
+            (request_builder.method, request_builder.url, request_builder.info)
         )
 
 

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -262,15 +262,12 @@ class RequestDefinition(interfaces.RequestDefinition):
 
     def define_request(self, request_builder, func_args, func_kwargs):
         request_builder.method = self._method
-        request_builder.url = utils.URIBuilder(self._uri)
+        request_builder.relative_url = self._uri
         request_builder.return_type = self._return_type
         self._argument_handler.handle_call(
             request_builder, func_args, func_kwargs
         )
         self._method_handler.handle_builder(request_builder)
-        # if an argument or method handler changes request_builder.url
-        # they MUST use utils.URIBuilder, not a string.
-        request_builder.url = request_builder.url.build()
 
 
 class HttpMethodFactory(object):

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -268,8 +268,9 @@ class RequestDefinition(interfaces.RequestDefinition):
             request_builder, func_args, func_kwargs
         )
         self._method_handler.handle_builder(request_builder)
-        if isinstance(request_builder.url, utils.URIBuilder):
-            request_builder.url = request_builder.url.build()
+        # if an argument or method handler changes request_builder.url
+        # they MUST use utils.URIBuilder, not a string.
+        request_builder.url = request_builder.url.build()
 
 
 class HttpMethodFactory(object):

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -268,7 +268,8 @@ class RequestDefinition(interfaces.RequestDefinition):
             request_builder, func_args, func_kwargs
         )
         self._method_handler.handle_builder(request_builder)
-        request_builder.url = request_builder.url.build()
+        if isinstance(request_builder.url, utils.URIBuilder):
+            request_builder.url = request_builder.url.build()
 
 
 class HttpMethodFactory(object):

--- a/uplink/helpers.py
+++ b/uplink/helpers.py
@@ -2,7 +2,7 @@
 import collections
 
 # Local imports
-from uplink import interfaces
+from uplink import interfaces, utils
 from uplink.clients import io
 
 
@@ -39,7 +39,7 @@ def set_api_definition(service, name, definition):
 class RequestBuilder(object):
     def __init__(self, client, converter_registry, base_url):
         self._method = None
-        self._url = None
+        self._relative_url_template = utils.URIBuilder("")
         self._return_type = None
         self._client = client
         self._base_url = base_url
@@ -69,13 +69,16 @@ class RequestBuilder(object):
     def base_url(self):
         return self._base_url
 
-    @property
-    def url(self):
-        return self._url
+    def set_url_variable(self, variables):
+        self._relative_url_template.set_variable(variables)
 
-    @url.setter
-    def url(self, url):
-        self._url = url
+    @property
+    def relative_url(self):
+        return self._relative_url_template.build()
+
+    @relative_url.setter
+    def relative_url(self, url):
+        self._relative_url_template = utils.URIBuilder(url)
 
     @property
     def info(self):

--- a/uplink/helpers.py
+++ b/uplink/helpers.py
@@ -107,6 +107,10 @@ class RequestBuilder(object):
     def request_template(self):
         return io.CompositeRequestTemplate(self._request_templates)
 
+    @property
+    def url(self):
+        return utils.urlparse.urljoin(self.base_url, self.relative_url)
+
     def add_transaction_hook(self, hook):
         self._transaction_hooks.append(hook)
 


### PR DESCRIPTION
Fixes #164 .

Changes proposed in this pull request:
- Check the type so `build()` isn't called on an already resolved string URL.

Attention: @prkumar