### PR TITLE
Fix Travis CI build by upgrading pytest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ extras_require = {
     # Twisted 19.7.0 dropped py3.4 support
     "twisted:python_version == '3.4'": "twisted<=19.2.1",
     "typing": ["typing>=3.6.4"],
-    "tests": ["pytest==5.2.1", "pytest-mock", "pytest-cov", "pytest-twisted"],
+    "tests": ["pytest==4.6.5", "pytest-mock", "pytest-cov", "pytest-twisted"],
 }
 
 metadata = {

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ extras_require = {
     # Twisted 19.7.0 dropped py3.4 support
     "twisted:python_version == '3.4'": "twisted<=19.2.1",
     "typing": ["typing>=3.6.4"],
-    "tests": ["pytest<4.1", "pytest-mock", "pytest-cov", "pytest-twisted"],
+    "tests": ["pytest==5.2.1", "pytest-mock", "pytest-cov", "pytest-twisted"],
 }
 
 metadata = {


### PR DESCRIPTION
Our CI build failures are related to pytest-dev/pytest#5903. We initially restricted pytest up to v4.1 in 64952e3 because pytest_twisted wasn't behaving well with the latest version of pytest at the time.