### PR TITLE
Exclude tests subpackages from resulting Python wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ metadata = {
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     "keywords": "http api rest client retrofit",
-    "packages": find_packages(exclude=("tests",)),
+    "packages": find_packages(exclude=("tests", "tests.*")),
     "install_requires": install_requires,
     "extras_require": extras_require,
 }


### PR DESCRIPTION
Currently ``uplink`` wheel contains ``tests`` subpackages but shouldn't. It happens because ``exclude`` argument to ``find_packages()`` function makes ``setuptools`` to exclude packages enumerated in that argument but not their subpackages and thus ``tests.unit`` and ``tests.integration`` appear in the resulting wheel.

Changes proposed in this pull request:
- Exclude ``tests.*`` subpackages together with ``tests``.

Attention: @prkumar