### PR TITLE
Fix FileNotFoundError in Python 3.6 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install flake8 flake8-bugbear; fi
 script:
   - tox -e py
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then flake8 uplink tests setup.py docs/conf.py; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then flake8 uplink tests setup.py docs/source/conf.py; fi
 after_success:
   - pip install codecov
   - codecov

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -133,9 +133,8 @@ html_static_path = ["_static"]
 
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
-    'index':    ['about.html', 'links.html', 'navigation.html', 'searchbox.html'],
-    '**':       ["about.html", 'localtoc.html', 'relations.html',
-                 'searchbox.html'],
+    'index': ['about.html', 'links.html', 'navigation.html', 'searchbox.html'],
+    '**': ["about.html", 'localtoc.html', 'relations.html', 'searchbox.html'],
     'changes': ['about.html', 'searchbox.html']
 }
 


### PR DESCRIPTION
The travis build for python 3.6 runs flake8 against particular files. Notably, we had `docs/conf.py` in this set, which was moved to `docs/source/conf.py`.