### PR TITLE
Make consumer method look like the original func

### DIFF
--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -14,7 +14,7 @@ class GitHubService(uplink.Consumer):
     @uplink.timeout(15)
     @uplink.get("/users/{user}/repos")
     def list_repos(self, user):
-        pass
+        """List all public repositories for a specific user."""
 
     @uplink.returns.json
     @uplink.get("/users/{user}/repos/{repo}")
@@ -24,6 +24,21 @@ class GitHubService(uplink.Consumer):
     @uplink.get(args={"url": uplink.Url})
     def forward(self, url):
         pass
+
+
+def test_list_repo_wrapper(mock_client):
+    """Ensures that the consumer method looks like the original func."""
+    github = GitHubService(base_url=BASE_URL, client=mock_client)
+    assert (
+        github.list_repos.__doc__
+        == GitHubService.list_repos.__doc__
+        == "List all public repositories for a specific user."
+    )
+    assert (
+        github.list_repos.__name__
+        == GitHubService.list_repos.__name__
+        == "list_repos"
+    )
 
 
 def test_list_repo(mock_client):

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -39,7 +39,6 @@ class TestHttpMethod(object):
         http_method = commands.HttpMethod("METHOD", uri="/{hello}")
         builder = http_method(func)
         assert isinstance(builder, commands.RequestDefinitionBuilder)
-        assert builder.__name__ == func.__name__
         assert builder.method == "METHOD"
         assert list(builder.uri.remaining_variables) == ["hello"]
 
@@ -133,6 +132,7 @@ class TestRequestDefinitionBuilder(object):
         builder = commands.RequestDefinitionBuilder(
             None,
             None,
+            None,
             type(annotation_handler_builder_mock)(),
             annotation_handler_builder_mock,
         )
@@ -143,6 +143,7 @@ class TestRequestDefinitionBuilder(object):
         method_handler_builder = annotation_handler_builder_mock
         uri_definition_builder = mocker.Mock(spec=commands.URIDefinitionBuilder)
         builder = commands.RequestDefinitionBuilder(
+            None,
             "method",
             uri_definition_builder,
             argument_handler_builder,
@@ -164,6 +165,7 @@ class TestRequestDefinitionBuilder(object):
         method_handler_builder = annotation_handler_builder_mock
         uri_definition_builder = mocker.Mock(spec=commands.URIDefinitionBuilder)
         builder = commands.RequestDefinitionBuilder(
+            None,
             "method",
             uri_definition_builder,
             argument_handler_builder,
@@ -189,6 +191,7 @@ class TestRequestDefinitionBuilder(object):
         method_handler_builder = annotation_handler_builder_mock
         uri_definition_builder = mocker.Mock(spec=commands.URIDefinitionBuilder)
         builder = commands.RequestDefinitionBuilder(
+            None,
             "method",
             uri_definition_builder,
             argument_handler_builder,

--- a/uplink/interfaces.py
+++ b/uplink/interfaces.py
@@ -96,6 +96,9 @@ class RequestDefinitionBuilder(object):
     def method_handler_builder(self):
         raise NotImplementedError
 
+    def update_wrapper(self, wrapper):
+        raise NotImplementedError
+
     def build(self):
         raise NotImplementedError
 


### PR DESCRIPTION
This involves copying function attributes (e.g., docstrings) using
`functools.update_wrapper`.

Original post on Gitter:
https://gitter.im/python-uplink/Lobby?at=5efcf94ce0e5673398e865e2