### PR TITLE
fix(collections): importing ABCs from collections directly is deprecated

### DIFF
--- a/uplink/arguments.py
+++ b/uplink/arguments.py
@@ -4,6 +4,7 @@ handling classes.
 """
 # Standard library imports
 import collections
+from collections import abc
 import functools
 import inspect
 
@@ -74,7 +75,7 @@ class ArgumentAnnotationHandlerBuilder(interfaces.AnnotationHandlerBuilder):
 
     def set_annotations(self, annotations=None, **more_annotations):
         if annotations is not None:
-            if not isinstance(annotations, collections.Mapping):
+            if not isinstance(annotations, abc.Mapping):
                 missing = tuple(
                     a
                     for a in self.missing_arguments
@@ -391,7 +392,7 @@ class Query(FuncDecoratorMixin, EncodeNoneMixin, NamedArgument):
     @staticmethod
     def update_params(info, new_params, encoded):
         existing = info.setdefault("params", None if encoded else dict())
-        if encoded == isinstance(existing, collections.Mapping):
+        if encoded == isinstance(existing, abc.Mapping):
             raise Query.QueryStringEncodingError()
         Query._update_params(info, existing, new_params, encoded)
 
@@ -801,7 +802,7 @@ class ContextMap(FuncDecoratorMixin, ArgumentAnnotation):
 
     def _modify_request(self, request_builder, value):
         """Updates the context with the given name-value pairs."""
-        if not isinstance(value, collections.Mapping):
+        if not isinstance(value, abc.Mapping):
             raise TypeError(
                 "ContextMap requires a mapping; got %s instead.", type(value)
             )

--- a/uplink/auth.py
+++ b/uplink/auth.py
@@ -1,7 +1,7 @@
 """This module implements the auth layer."""
 
 # Standard library imports
-import collections
+from collections import abc
 
 # Third-party imports
 from requests import auth
@@ -22,7 +22,7 @@ __all__ = [
 def get_auth(auth_object=None):
     if auth_object is None:
         return utils.no_op
-    elif isinstance(auth_object, collections.Iterable):
+    elif isinstance(auth_object, abc.Iterable):
         return BasicAuth(*auth_object)
     elif callable(auth_object):
         return auth_object

--- a/uplink/clients/io/interfaces.py
+++ b/uplink/clients/io/interfaces.py
@@ -1,5 +1,5 @@
 # Standard library imports
-import collections
+from collections import abc
 
 # Local imports
 from uplink import compat
@@ -69,7 +69,7 @@ class SleepCallback(object):
         raise NotImplementedError
 
 
-class Executable(collections.Iterator):
+class Executable(abc.Iterator):
     """An abstraction for iterating over the execution of a request."""
 
     def __next__(self):

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -1,5 +1,5 @@
 # Standard library imports
-import collections
+from collections import abc
 import functools
 
 # Local imports
@@ -321,7 +321,7 @@ class HttpMethod(object):
 
         # Register argument annotations
         if args:
-            is_map = isinstance(args, collections.Mapping)
+            is_map = isinstance(args, abc.Mapping)
             args, kwargs = ((), args) if is_map else (args, {})
             self._add_args = decorators.args(*args, **kwargs)
 

--- a/uplink/converters/__init__.py
+++ b/uplink/converters/__init__.py
@@ -1,5 +1,5 @@
 # Standard library imports
-import collections
+from collections import abc
 
 # Local imports
 from uplink._extras import installer, plugin
@@ -57,7 +57,7 @@ class ConverterChain(object):
         return converter
 
 
-class ConverterFactoryRegistry(collections.Mapping):
+class ConverterFactoryRegistry(abc.Mapping):
     """
     A registry that chains together
     :py:class:`interfaces.ConverterFactory` instances.

--- a/uplink/converters/typing_.py
+++ b/uplink/converters/typing_.py
@@ -1,5 +1,6 @@
 # Standard library imports
 import collections
+from collections import abc
 import functools
 
 # Local imports
@@ -25,7 +26,7 @@ class ListConverter(BaseTypeConverter, interfaces.Converter):
         self._elem_converter = chain(self._elem_type) or self._elem_type
 
     def convert(self, value):
-        if isinstance(value, collections.Sequence):
+        if isinstance(value, abc.Sequence):
             return list(map(self._elem_converter, value))
         else:
             # TODO: Handle the case where the value is not an sequence.
@@ -44,7 +45,7 @@ class DictConverter(BaseTypeConverter, interfaces.Converter):
         self._value_converter = chain(self._value_type) or self._value_type
 
     def convert(self, value):
-        if isinstance(value, collections.Mapping):
+        if isinstance(value, abc.Mapping):
             key_c, val_c = self._key_converter, self._value_converter
             return dict((key_c(k), val_c(value[k])) for k in value)
         else:

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -3,7 +3,7 @@ This module implements the built-in class and method decorators and their
 handling classes.
 """
 # Standard library imports
-import collections
+from collections import abc
 import functools
 import inspect
 
@@ -281,7 +281,7 @@ class json(MethodAnnotation):
     You can annotate a method argument with :py:class:`uplink.Body`,
     which indicates that the argument's value should become the
     request's body. :py:class:`uplink.Body` has to be either a dict or a
-    subclass of py:class:`collections.Mapping`.
+    subclass of py:class:`abc.Mapping`.
 
     Example:
         .. code-block:: python
@@ -343,7 +343,7 @@ class json(MethodAnnotation):
             raise ValueError("Path sequence cannot be empty.")
         for name in path[:-1]:
             body = body.setdefault(name, {})
-            if not isinstance(body, collections.Mapping):
+            if not isinstance(body, abc.Mapping):
                 raise ValueError(
                     "Failed to set nested JSON attribute '%s': "
                     "parent field '%s' is not a JSON object." % (path, name)
@@ -357,7 +357,7 @@ class json(MethodAnnotation):
     @classmethod
     def set_json_body(cls, request_builder):
         old_body = request_builder.info.pop("data", {})
-        if isinstance(old_body, collections.Mapping):
+        if isinstance(old_body, abc.Mapping):
             body = request_builder.info.setdefault("json", {})
             for path in old_body:
                 if isinstance(path, tuple):


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix the import path of the ABC classes used in the project.

Attention: @prkumar