### PR TITLE
support passing pydantic original model as request body

### DIFF
--- a/tests/unit/test_converters.py
+++ b/tests/unit/test_converters.py
@@ -483,6 +483,24 @@ class TestPydanticConverter(object):
         assert result == expected_result
         model_mock.dict.assert_called_once()
 
+    def test_create_request_body_converter_with_original_model(
+        self, pydantic_model_mock
+    ):
+        expected_result = {"id": 0}
+
+        model_mock, model = pydantic_model_mock
+        model_mock.dict.return_value = expected_result
+
+        request_body = model()
+
+        converter = converters.PydanticConverter()
+        request_converter = converter.create_request_body_converter(model)
+
+        result = request_converter.convert(request_body)
+
+        assert result == expected_result
+        model_mock.dict.assert_called_once()
+
     def test_create_request_body_converter_without_schema(self, mocker):
         expected_result = None
         converter = converters.PydanticConverter()

--- a/uplink/converters/pydantic_.py
+++ b/uplink/converters/pydantic_.py
@@ -13,7 +13,10 @@ class _PydanticRequestBody(Converter):
         self._model = model
 
     def convert(self, value):
-        return self._model(**value).dict()
+        if isinstance(value, self._model):
+            return value.dict()
+        else:
+            return self._model(**value).dict()
 
 
 class _PydanticResponseBody(Converter):


### PR DESCRIPTION
Changes proposed in this pull request:
- support passing pydantic original model as request body

```python
from pydantic import BaseModel
from uplink import Consumer, Body

class CreateRepo(BaseModel):
   name: str
   delete_branch_on_merge: bool = False

class GitHub(Consumer):
   @post("user/repos")
   def create_repo(self, repo: Body(type=CreateRepo)):
      """Creates a new repository for the authenticated user."""


github = GitHub(base_url="https://api.github.com")
repo = CreateRepo(name="my_favorite_new_project")
github.create_repo(repo)  # instead of github.create_repo(repo.dict())
```

Attention: @prkumar