### PR TITLE
Release v0.9.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to the
 `Semantic Versioning`_ scheme.
 
+0.9.3_ - 2020-11-22
+====================
+Added
+-----
+- Support for serialization using a subclass of `pydantic`_'s `BaseModel` that
+  contains fields of a complex type, such as `datetime`.
+  (`#207`_ by `@leiserfg`_)
+- Support for passing a subclass of `pydantic`'s `BaseModel` as the request
+  body. (`#209`_ by `@lust4life`_)
+
 0.9.2_ - 2020-10-18
 ====================
 Added
@@ -367,6 +377,8 @@ Added
 .. _#198: https://github.com/prkumar/uplink/pull/198
 .. _#200: https://github.com/prkumar/uplink/pull/200
 .. _#204: https://github.com/prkumar/uplink/pull/204
+.. _#207: https://github.com/prkumar/uplink/pull/207
+.. _#209: https://github.com/prkumar/uplink/pull/209
 
 .. Contributors
 .. _@daa: https://github.com/daa
@@ -376,3 +388,5 @@ Added
 .. _@kadrach: https://github.com/kadrach
 .. _@cognifloyd: https://github.com/cognifloyd
 .. _@gmcrocetti: https://github.com/gmcrocetti
+.. _@leiserfg: https://github.com/leiserfg
+.. _@lust4life: https://github.com/lust4life

--- a/docs/source/user/quickstart.rst
+++ b/docs/source/user/quickstart.rst
@@ -236,7 +236,7 @@ Request Body
 ============
 
 The :py:class:`~uplink.Body` annotation identifies a method argument as the
-the HTTP request body:
+HTTP request body:
 
 .. code-block:: python
 

--- a/tests/unit/test_converters.py
+++ b/tests/unit/test_converters.py
@@ -482,6 +482,28 @@ class TestPydanticConverter(object):
 
         assert result == expected_result
         model_mock.dict.assert_called_once()
+        model_mock.dict.assert_called_once()
+
+    def test_convert_complex_model(self):
+        from json import loads
+        from datetime import datetime
+        from typing import List
+
+        class ComplexModel(pydantic.BaseModel):
+            when = datetime.utcnow()  # type: datetime
+            where = 'http://example.com'  # type: pydantic.AnyUrl
+            some = [1]  # type: List[int]
+
+        model = ComplexModel()
+        request_body = {}
+        expected_result = loads(model.json())
+
+        converter = converters.PydanticConverter()
+        request_converter = converter.create_request_body_converter(ComplexModel)
+
+        result = request_converter.convert(request_body)
+
+        assert result == expected_result
 
     def test_create_request_body_converter_without_schema(self, mocker):
         expected_result = None

--- a/tests/unit/test_converters.py
+++ b/tests/unit/test_converters.py
@@ -505,6 +505,24 @@ class TestPydanticConverter(object):
 
         assert result == expected_result
 
+    def test_create_request_body_converter_with_original_model(
+        self, pydantic_model_mock
+    ):
+        expected_result = {"id": 0}
+
+        model_mock, model = pydantic_model_mock
+        model_mock.dict.return_value = expected_result
+
+        request_body = model()
+
+        converter = converters.PydanticConverter()
+        request_converter = converter.create_request_body_converter(model)
+
+        result = request_converter.convert(request_body)
+
+        assert result == expected_result
+        model_mock.dict.assert_called_once()
+
     def test_create_request_body_converter_without_schema(self, mocker):
         expected_result = None
         converter = converters.PydanticConverter()

--- a/uplink/__about__.py
+++ b/uplink/__about__.py
@@ -3,4 +3,4 @@ This module is the single source of truth for any package metadata
 that is used both in distribution (i.e., setup.py) and within the
 codebase.
 """
-__version__ = "0.9.2"
+__version__ = "0.9.3"

--- a/uplink/converters/pydantic_.py
+++ b/uplink/converters/pydantic_.py
@@ -30,6 +30,8 @@ class _PydanticRequestBody(Converter):
         self._model = model
 
     def convert(self, value):
+        if isinstance(value, self._model):
+            return _encode_pydantic(value)
         return _encode_pydantic(self._model.parse_obj(value))
 
 


### PR DESCRIPTION
Added
-----
- Support for serialization using a subclass of `pydantic`_'s `BaseModel` that
  contains fields of a complex type, such as `datetime`.
- Support for passing a subclass of `pydantic`'s `BaseModel` as the request
  body.