### PR TITLE
Release v0.9.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,17 +10,17 @@ The format is based on `Keep a Changelog`_, and this project adheres to the
 ====================
 Added
 -----
-- Support for serialization using a subclass of `pydantic`_'s `BaseModel` that
-  contains fields of a complex type, such as `datetime`.
+- Support for serialization using a subclass of `pydantic`_'s ``BaseModel`` that
+  contains fields of a complex type, such as ``datetime``.
   (`#207`_ by `@leiserfg`_)
-- Support for passing a subclass of `pydantic`'s `BaseModel` as the request
+- Support for passing a subclass of `pydantic`'s ``BaseModel`` as the request
   body. (`#209`_ by `@lust4life`_)
 
 0.9.2_ - 2020-10-18
 ====================
 Added
 -----
-- Support for (de)serializing subclasses of `pydantic`_'s `BaseModel`
+- Support for (de)serializing subclasses of `pydantic`_'s ``BaseModel``
   (`#200`_ by `@gmcrocetti`_)
 
 Fixed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -333,6 +333,7 @@ Added
 .. _pydantic: https://pydantic-docs.helpmanual.io/
 
 .. Releases
+.. _0.9.3: https://github.com/prkumar/uplink/compare/v0.9.2...v0.9.3
 .. _0.9.2: https://github.com/prkumar/uplink/compare/v0.9.1...v0.9.2
 .. _0.9.1: https://github.com/prkumar/uplink/compare/v0.9.0...v0.9.1
 .. _0.9.0: https://github.com/prkumar/uplink/compare/v0.8.0...v0.9.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to the
 `Semantic Versioning`_ scheme.
 
+0.9.4_ - 2021-02-08
+====================
+Fixed
+-----
+- A type set as a consumer method's return annotation should not be used to
+  deserialize a response object if no registered converters can handle the type.
+  (`3653a672ee`_)
+
 0.9.3_ - 2020-11-22
 ====================
 Added
@@ -333,6 +341,7 @@ Added
 .. _pydantic: https://pydantic-docs.helpmanual.io/
 
 .. Releases
+.. _0.9.4: https://github.com/prkumar/uplink/compare/v0.9.3...v0.9.4
 .. _0.9.3: https://github.com/prkumar/uplink/compare/v0.9.2...v0.9.3
 .. _0.9.2: https://github.com/prkumar/uplink/compare/v0.9.1...v0.9.2
 .. _0.9.1: https://github.com/prkumar/uplink/compare/v0.9.0...v0.9.1
@@ -380,6 +389,9 @@ Added
 .. _#204: https://github.com/prkumar/uplink/pull/204
 .. _#207: https://github.com/prkumar/uplink/pull/207
 .. _#209: https://github.com/prkumar/uplink/pull/209
+
+.. Commits
+.. _3653a672ee: https://github.com/prkumar/uplink/commit/3653a672ee0703119720d0077bb450649af5459c
 
 .. Contributors
 .. _@daa: https://github.com/daa

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to the
 `Semantic Versioning`_ scheme.
 
-0.9.4_ - 2021-02-08
+0.9.4_ - 2021-02-15
 ====================
 Fixed
 -----

--- a/tests/unit/test_converters.py
+++ b/tests/unit/test_converters.py
@@ -44,13 +44,23 @@ class TestStringConverter(object):
 
 
 class TestStandardConverter(object):
-    def test_create_response_body_converter(self, converter_mock):
+    def test_create_response_body_converter_with_converter(
+        self, converter_mock
+    ):
         # Setup
         factory = standard.StandardConverter()
 
         # Run & Verify: Pass-through converters
         converter = factory.create_response_body_converter(converter_mock)
         assert converter is converter_mock
+
+    def test_create_response_body_converter_with_unknown_type(self):
+        # Setup
+        factory = standard.StandardConverter()
+
+        # Run & Verify: does not know how to convert any types
+        converter = factory.create_response_body_converter(dict)
+        assert converter is None
 
 
 class TestConverterFactoryRegistry(object):
@@ -487,19 +497,20 @@ class TestPydanticConverter(object):
     def test_convert_complex_model(self):
         from json import loads
         from datetime import datetime
-        from typing import List
 
         class ComplexModel(pydantic.BaseModel):
             when = datetime.utcnow()  # type: datetime
-            where = 'http://example.com'  # type: pydantic.AnyUrl
-            some = [1]  # type: List[int]
+            where = "http://example.com"  # type: pydantic.AnyUrl
+            some = [1]  # type: typing.List[int]
 
         model = ComplexModel()
         request_body = {}
         expected_result = loads(model.json())
 
         converter = converters.PydanticConverter()
-        request_converter = converter.create_request_body_converter(ComplexModel)
+        request_converter = converter.create_request_body_converter(
+            ComplexModel
+        )
 
         result = request_converter.convert(request_body)
 

--- a/tests/unit/test_converters.py
+++ b/tests/unit/test_converters.py
@@ -505,6 +505,24 @@ class TestPydanticConverter(object):
 
         assert result == expected_result
 
+    def test_create_request_body_converter_with_original_model(
+        self, pydantic_model_mock
+    ):
+        expected_result = {"id": 0}
+
+        model_mock, model = pydantic_model_mock
+        model_mock.dict.return_value = expected_result
+
+        request_body = model()
+
+        converter = converters.PydanticConverter()
+        request_converter = converter.create_request_body_converter(model)
+
+        result = request_converter.convert(request_body)
+
+        assert result == expected_result
+        model_mock.dict.assert_called_once()
+
     def test_create_request_body_converter_without_schema(self, mocker):
         expected_result = None
         converter = converters.PydanticConverter()

--- a/tests/unit/test_converters.py
+++ b/tests/unit/test_converters.py
@@ -18,25 +18,6 @@ from uplink import converters
 from uplink.converters import register, standard
 
 
-class TestCast(object):
-    def test_converter_without_caster(self, mocker):
-        converter_mock = mocker.stub()
-        converter_mock.return_value = 2
-        cast = standard.Cast(None, converter_mock)
-        return_value = cast.convert(1)
-        converter_mock.assert_called_with(1)
-        assert return_value == 2
-
-    def test_convert_with_caster(self, mocker):
-        caster = mocker.Mock(return_value=2)
-        converter_mock = mocker.Mock(return_value=3)
-        cast = standard.Cast(caster, converter_mock)
-        return_value = cast.convert(1)
-        caster.assert_called_with(1)
-        converter_mock.assert_called_with(2)
-        assert return_value == 3
-
-
 class TestStringConverter(object):
     def test_convert(self):
         converter_ = standard.StringConverter()
@@ -58,9 +39,44 @@ class TestStandardConverter(object):
         # Setup
         factory = standard.StandardConverter()
 
-        # Run & Verify: does not know how to convert any types
+        # Run & Verify: does not know how to create converter when given a type
+        # that is not a converter
         converter = factory.create_response_body_converter(dict)
         assert converter is None
+
+    def test_create_request_body_converter_with_converter(self, converter_mock):
+        # Setup
+        factory = standard.StandardConverter()
+
+        # Run & Verify: Pass-through converters
+        converter = factory.create_request_body_converter(converter_mock)
+        assert converter is converter_mock
+
+    def test_create_request_body_converter_with_unknown_type(self):
+        # Setup
+        factory = standard.StandardConverter()
+
+        # Run & Verify: does not know how to create converter when given a type
+        # that is not a converter
+        converter = factory.create_response_body_converter(dict)
+        assert converter is None
+
+    def test_create_string_converter_with_converter(self, converter_mock):
+        # Setup
+        factory = standard.StandardConverter()
+
+        # Run & Verify: Pass-through converters
+        converter = factory.create_string_converter(converter_mock)
+        assert converter is converter_mock
+
+    def test_create_string_converter_with_unknown_type(self):
+        # Setup
+        factory = standard.StandardConverter()
+
+        # Run & Verify: creates string converter when given type is not a
+        # converter
+        converter = factory.create_string_converter(dict)
+        assert isinstance(converter, standard.StringConverter)
 
 
 class TestConverterFactoryRegistry(object):

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -260,7 +260,7 @@ def test_json_list(request_builder):
 def test_timeout(request_builder):
     timeout = decorators.timeout(60)
     timeout.modify_request(request_builder)
-    request_builder.info["timeout"] == 60
+    assert request_builder.info["timeout"] == 60
 
 
 def test_args(request_definition_builder):

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -54,8 +54,8 @@ class TestTransactionHookChain(object):
             hooks.ResponseHandler(mock_response_handler),
         )
         chain.handle_response("consumer", {})
-        mock_response_handler.call_count == 2
-        mock_request_auditor.call_count == 1
+        assert mock_response_handler.call_count == 2
+        assert mock_request_auditor.call_count == 1
 
     def test_delegate_handle_exception(self, transaction_hook_mock):
         class CustomException(Exception):

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -55,7 +55,7 @@ class TestTransactionHookChain(object):
         )
         chain.handle_response("consumer", {})
         assert mock_response_handler.call_count == 2
-        assert mock_request_auditor.call_count == 1
+        assert mock_request_auditor.call_count == 0
 
     def test_delegate_handle_exception(self, transaction_hook_mock):
         class CustomException(Exception):

--- a/uplink/__about__.py
+++ b/uplink/__about__.py
@@ -3,4 +3,4 @@ This module is the single source of truth for any package metadata
 that is used both in distribution (i.e., setup.py) and within the
 codebase.
 """
-__version__ = "0.9.3"
+__version__ = "0.9.4"

--- a/uplink/arguments.py
+++ b/uplink/arguments.py
@@ -4,6 +4,7 @@ handling classes.
 """
 # Standard library imports
 import collections
+from collections import abc
 import functools
 import inspect
 
@@ -74,7 +75,7 @@ class ArgumentAnnotationHandlerBuilder(interfaces.AnnotationHandlerBuilder):
 
     def set_annotations(self, annotations=None, **more_annotations):
         if annotations is not None:
-            if not isinstance(annotations, collections.Mapping):
+            if not isinstance(annotations, abc.Mapping):
                 missing = tuple(
                     a
                     for a in self.missing_arguments
@@ -392,7 +393,7 @@ class Query(FuncDecoratorMixin, EncodeNoneMixin, NamedArgument):
     @staticmethod
     def update_params(info, new_params, encoded):
         existing = info.setdefault("params", None if encoded else dict())
-        if encoded == isinstance(existing, collections.Mapping):
+        if encoded == isinstance(existing, abc.Mapping):
             raise Query.QueryStringEncodingError()
         Query._update_params(info, existing, new_params, encoded)
 
@@ -802,7 +803,7 @@ class ContextMap(FuncDecoratorMixin, ArgumentAnnotation):
 
     def _modify_request(self, request_builder, value):
         """Updates the context with the given name-value pairs."""
-        if not isinstance(value, collections.Mapping):
+        if not isinstance(value, abc.Mapping):
             raise TypeError(
                 "ContextMap requires a mapping; got %s instead.", type(value)
             )

--- a/uplink/auth.py
+++ b/uplink/auth.py
@@ -1,7 +1,7 @@
 """This module implements the auth layer."""
 
 # Standard library imports
-import collections
+from collections import abc
 
 # Third-party imports
 from requests import auth
@@ -22,7 +22,7 @@ __all__ = [
 def get_auth(auth_object=None):
     if auth_object is None:
         return utils.no_op
-    elif isinstance(auth_object, collections.Iterable):
+    elif isinstance(auth_object, abc.Iterable):
         return BasicAuth(*auth_object)
     elif callable(auth_object):
         return auth_object

--- a/uplink/clients/io/interfaces.py
+++ b/uplink/clients/io/interfaces.py
@@ -1,5 +1,5 @@
 # Standard library imports
-import collections
+from collections import abc
 
 # Local imports
 from uplink import compat
@@ -69,7 +69,7 @@ class SleepCallback(object):
         raise NotImplementedError
 
 
-class Executable(collections.Iterator):
+class Executable(abc.Iterator):
     """An abstraction for iterating over the execution of a request."""
 
     def __next__(self):

--- a/uplink/clients/io/transitions.py
+++ b/uplink/clients/io/transitions.py
@@ -47,6 +47,8 @@ def fail(exc_type, exc_val, exc_tb):
     """
     Transitions the execution to fail with a specific error.
 
+    This will prompt the execution of any RequestTemplate.after_exception hooks.
+
     Args:
         exc_type: The exception class.
         exc_val: The exception object.
@@ -62,6 +64,8 @@ def fail(exc_type, exc_val, exc_tb):
 def prepare(request):
     """
     Transitions the execution to prepare the given request.
+
+    This will prompt the execution of any RequestTemplate.before_request.
 
     Args:
         request: The intended request data to be sent.

--- a/uplink/commands.py
+++ b/uplink/commands.py
@@ -1,5 +1,5 @@
 # Standard library imports
-import collections
+from collections import abc
 import functools
 
 # Local imports
@@ -321,7 +321,7 @@ class HttpMethod(object):
 
         # Register argument annotations
         if args:
-            is_map = isinstance(args, collections.Mapping)
+            is_map = isinstance(args, abc.Mapping)
             args, kwargs = ((), args) if is_map else (args, {})
             self._add_args = decorators.args(*args, **kwargs)
 

--- a/uplink/converters/__init__.py
+++ b/uplink/converters/__init__.py
@@ -1,5 +1,5 @@
 # Standard library imports
-import collections
+from collections import abc
 
 # Local imports
 from uplink._extras import installer, plugin
@@ -57,7 +57,7 @@ class ConverterChain(object):
         return converter
 
 
-class ConverterFactoryRegistry(collections.Mapping):
+class ConverterFactoryRegistry(abc.Mapping):
     """
     A registry that chains together
     :py:class:`interfaces.ConverterFactory` instances.

--- a/uplink/converters/pydantic_.py
+++ b/uplink/converters/pydantic_.py
@@ -30,6 +30,8 @@ class _PydanticRequestBody(Converter):
         self._model = model
 
     def convert(self, value):
+        if isinstance(value, self._model):
+            return _encode_pydantic(value)
         return _encode_pydantic(self._model.parse_obj(value))
 
 

--- a/uplink/converters/standard.py
+++ b/uplink/converters/standard.py
@@ -2,20 +2,6 @@
 from uplink.converters import interfaces, register_default_converter_factory
 
 
-class Cast(interfaces.Converter):
-    def __init__(self, caster, converter):
-        self._cast = caster
-        self._converter = converter
-
-    def set_chain(self, chain):
-        self._converter.set_chain(chain)
-
-    def convert(self, value):
-        if callable(self._cast):
-            value = self._cast(value)
-        return self._converter(value)
-
-
 class StringConverter(interfaces.Converter):
     def convert(self, value):
         return str(value)
@@ -29,12 +15,15 @@ class StandardConverter(interfaces.Factory):
     converters could handle a particular type.
     """
 
-    def create_request_body_converter(self, cls, request_definition):
-        return cls
+    def create_request_body_converter(self, cls, *args, **kwargs):
+        if isinstance(cls, interfaces.Converter):
+            return cls
 
     def create_response_body_converter(self, cls, *args, **kwargs):
         if isinstance(cls, interfaces.Converter):
             return cls
 
-    def create_string_converter(self, type_, *args, **kwargs):
-        return Cast(type_, StringConverter())  # pragma: no cover
+    def create_string_converter(self, cls, *args, **kwargs):
+        if isinstance(cls, interfaces.Converter):
+            return cls
+        return StringConverter()

--- a/uplink/converters/standard.py
+++ b/uplink/converters/standard.py
@@ -29,13 +29,12 @@ class StandardConverter(interfaces.Factory):
     converters could handle a particular type.
     """
 
-    @staticmethod
-    def pass_through_converter(type_, *args, **kwargs):
-        return type_
+    def create_request_body_converter(self, cls, request_definition):
+        return cls
 
-    create_response_body_converter = (
-        create_request_body_converter
-    ) = pass_through_converter
+    def create_response_body_converter(self, cls, *args, **kwargs):
+        if isinstance(cls, interfaces.Converter):
+            return cls
 
     def create_string_converter(self, type_, *args, **kwargs):
         return Cast(type_, StringConverter())  # pragma: no cover

--- a/uplink/converters/typing_.py
+++ b/uplink/converters/typing_.py
@@ -1,5 +1,6 @@
 # Standard library imports
 import collections
+from collections import abc
 import functools
 
 # Local imports
@@ -25,7 +26,7 @@ class ListConverter(BaseTypeConverter, interfaces.Converter):
         self._elem_converter = chain(self._elem_type) or self._elem_type
 
     def convert(self, value):
-        if isinstance(value, collections.Sequence):
+        if isinstance(value, abc.Sequence):
             return list(map(self._elem_converter, value))
         else:
             # TODO: Handle the case where the value is not an sequence.
@@ -44,7 +45,7 @@ class DictConverter(BaseTypeConverter, interfaces.Converter):
         self._value_converter = chain(self._value_type) or self._value_type
 
     def convert(self, value):
-        if isinstance(value, collections.Mapping):
+        if isinstance(value, abc.Mapping):
             key_c, val_c = self._key_converter, self._value_converter
             return dict((key_c(k), val_c(value[k])) for k in value)
         else:

--- a/uplink/decorators.py
+++ b/uplink/decorators.py
@@ -3,7 +3,7 @@ This module implements the built-in class and method decorators and their
 handling classes.
 """
 # Standard library imports
-import collections
+from collections import abc
 import functools
 import inspect
 
@@ -281,7 +281,7 @@ class json(MethodAnnotation):
     You can annotate a method argument with :py:class:`uplink.Body`,
     which indicates that the argument's value should become the
     request's body. :py:class:`uplink.Body` has to be either a dict or a
-    subclass of py:class:`collections.Mapping`.
+    subclass of py:class:`abc.Mapping`.
 
     Example:
         .. code-block:: python
@@ -343,7 +343,7 @@ class json(MethodAnnotation):
             raise ValueError("Path sequence cannot be empty.")
         for name in path[:-1]:
             body = body.setdefault(name, {})
-            if not isinstance(body, collections.Mapping):
+            if not isinstance(body, abc.Mapping):
                 raise ValueError(
                     "Failed to set nested JSON attribute '%s': "
                     "parent field '%s' is not a JSON object." % (path, name)
@@ -357,7 +357,7 @@ class json(MethodAnnotation):
     @classmethod
     def set_json_body(cls, request_builder):
         old_body = request_builder.info.pop("data", {})
-        if isinstance(old_body, collections.Mapping):
+        if isinstance(old_body, abc.Mapping):
             body = request_builder.info.setdefault("json", {})
             for path in old_body:
                 if isinstance(path, tuple):


### PR DESCRIPTION
Fixed
-----
- A type set as a consumer method's return annotation should not be used to
  deserialize a response object if no registered converters can handle the type.
  ([3653a672ee](https://github.com/prkumar/uplink/commit/3653a672ee0703119720d0077bb450649af5459c))