### PR TITLE
Update arguments.py - update docstring to match quickstart

### DIFF
--- a/uplink/arguments.py
+++ b/uplink/arguments.py
@@ -288,7 +288,7 @@ class Path(NamedArgument):
     .. code-block:: python
 
         class TodoService(object):
-            @get("/todos{/id}")
+            @get("/todos/{id}")
             def get_todo(self, todo_id: Path("id")): pass
 
     Then, invoking :code:`get_todo` with a consumer instance:
@@ -308,7 +308,7 @@ class Path(NamedArgument):
 
         .. code-block:: python
 
-            @get("/todos{/id}")
+            @get("/todos/{id}")
             def get_todo(self, id): pass
     """
 


### PR DESCRIPTION
the docstring in docs which is referenced https://uplink.readthedocs.io/en/stable/dev/types.html?highlight=path#uplink.Path, and is different than what's in the quickstart: https://uplink.readthedocs.io/en/stable/user/quickstart.html#path-parameters



Changes proposed in this pull request:
- update docstring in arguments.py

 
Attention: @prkumar