### PR TITLE
Fix `@returns.json` support for casting response using provided type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,11 +10,21 @@ Unreleased
 ==========
 Added
 -----
-- Add a new base class, ``uplink.retry.RetryBackoff``, which can be extended to implement custom backoff strategies. An instance of a ``RetryBackoff`` subclass can be provided through the ``backoff`` argument of the ``@retry`` decorator. (`#238`_)
+- Add a new base class, ``uplink.retry.RetryBackoff``, which can be extended to
+  implement custom backoff strategies. An instance of a ``RetryBackoff`` subclass
+  can be provided through the ``backoff`` argument of the ``@retry`` decorator.
+  (`#238`_)
 
 Changed
 -------
 - Bump minimum version of ``six`` to ``1.13.0``. (`#246`_)
+
+Fixed
+-----
+- Fix ``@returns.json`` to cast JSON response (or field referenced by the ``key``
+  argument) when the ``type`` argument is callable. This effectively reverts a
+  change in the decorator's behavior that was introduced in v0.9.3. (`#215`_)
+
 
 0.9.5_ - 2022-01-04
 ====================
@@ -415,6 +425,7 @@ Added
 .. _#204: https://github.com/prkumar/uplink/pull/204
 .. _#207: https://github.com/prkumar/uplink/pull/207
 .. _#209: https://github.com/prkumar/uplink/pull/209
+.. _#215: https://github.com/prkumar/uplink/issues/215
 .. _#217: https://github.com/prkumar/uplink/issues/217
 .. _#221: https://github.com/prkumar/uplink/issues/221
 .. _#237: https://github.com/prkumar/uplink/discussions/237

--- a/tests/integration/test_returns.py
+++ b/tests/integration/test_returns.py
@@ -59,8 +59,30 @@ class GitHub(uplink.Consumer):
     def create_repo(self, user, repo):
         pass
 
+    @uplink.returns(object)
+    @uplink.get("/users")
+    def list_users(self):
+        pass
+
 
 # Tests
+
+
+def test_returns_response_when_type_has_no_converter(
+    mock_client, mock_response
+):
+    # Setup
+    mock_response.with_json({"id": 123, "name": "prkumar"})
+    mock_client.with_response(mock_response)
+    github = GitHub(
+        base_url=BASE_URL, client=mock_client, converters=user_reader
+    )
+
+    # Run
+    response = github.list_users()
+
+    # Verify
+    assert response == mock_response
 
 
 def test_returns_with_type(mock_client, mock_response):

--- a/tests/integration/test_returns.py
+++ b/tests/integration/test_returns.py
@@ -54,6 +54,11 @@ class GitHub(uplink.Consumer):
     def get_first_repo_size(self, user):
         pass
 
+    @uplink.returns.from_json(key=("data", 0, "stars"), type=int)
+    @uplink.get("/users/{user}/repos")
+    def get_first_repo_stars(self, user):
+        pass
+
     @uplink.json
     @uplink.post("/users/{user}/repos", args={"repo": uplink.Body(Repo)})
     def create_repo(self, user, repo):
@@ -160,6 +165,27 @@ def test_returns_json_by_key(mock_client, mock_response):
 
     # Verify
     assert size == 300
+
+
+def test_returns_json_with_key_and_type(mock_client, mock_response):
+    # Setup
+    mock_response.with_json(
+        {
+            "data": [
+                {"owner": "prkumar", "name": "uplink", "stars": "300"},
+                {"owner": "prkumar", "name": "uplink-protobuf", "stars": "400"},
+            ],
+            "errors": [],
+        }
+    )
+    mock_client.with_response(mock_response)
+    github = GitHub(base_url=BASE_URL, client=mock_client)
+
+    # Run
+    stars = github.get_first_repo_stars("prkumar")
+
+    # Verify
+    assert stars == 300
 
 
 def test_post_json(mock_client):

--- a/tests/unit/test_returns.py
+++ b/tests/unit/test_returns.py
@@ -1,6 +1,4 @@
 # Local imports
-import pytest
-
 from uplink import returns
 
 
@@ -21,9 +19,7 @@ def test_returns_with_multiple_decorators(request_builder, mocker):
     first_type = returns.ReturnType.with_decorator(None, decorator1)
     second_type = (
         request_builder.return_type
-    ) = returns.ReturnType.with_decorator(
-        first_type, decorator2
-    )
+    ) = returns.ReturnType.with_decorator(first_type, decorator2)
 
     # Verify that the return type doesn't change after being handled by first decorator
     decorator1.modify_request(request_builder)
@@ -101,15 +97,15 @@ class TestReturnsJsonCast(object):
         returns_json.modify_request(request_builder)
         return mock_response
 
-    def test_without_cast(self, request_builder, mocker):
-        mock_response = self.prepare_test(
-            request_builder, mocker, type=int, key="key", cast=False
-        )
+    def test_without_type(self, request_builder, mocker):
+        mock_response = self.prepare_test(request_builder, mocker, key="key")
         assert request_builder.return_type(mock_response) == "1"
 
-    def test_with_cast(self, request_builder, mocker):
+    def test_with_callable_type(self, request_builder, mocker):
         mock_response = self.prepare_test(
-            request_builder, mocker, type=lambda _: "test", cast=True
+            request_builder,
+            mocker,
+            type=lambda _: "test",
         )
         assert request_builder.return_type(mock_response) == "test"
 
@@ -126,8 +122,8 @@ class TestReturnsJsonCast(object):
         assert request_builder.return_type(mock_response) == 1
 
     def test_with_not_callable_cast(self, request_builder, mocker):
-        with pytest.raises(ValueError):
-            self.prepare_test(request_builder, mocker, type=1, cast=True)
+        mock_response = self.prepare_test(request_builder, mocker, type=1)
+        assert request_builder.return_type(mock_response) == self.default_value
 
 
 def test_returns_JsonStrategy(mocker):
@@ -138,5 +134,3 @@ def test_returns_JsonStrategy(mocker):
 
     converter = returns.JsonStrategy(lambda y: y + "!", "hello")
     assert converter(response) == "world!"
-
-    assert returns.JsonStrategy(1).unwrap() == 1

--- a/tests/unit/test_returns.py
+++ b/tests/unit/test_returns.py
@@ -1,4 +1,6 @@
 # Local imports
+import pytest
+
 from uplink import returns
 
 
@@ -59,14 +61,73 @@ def test_returns_json(request_builder, mocker):
         mock_response.json()
     )
 
-    # Verify: Doesn't apply to unsupported types
+    # Verify: Returns JSON when type cannot be converted
     request_builder.get_converter.return_value = None
-    returns_json = returns.json(str, ())
+    returns_json = returns.json(None, ())
     request_builder.return_type = returns.ReturnType.with_decorator(
         None, returns_json
     )
     returns_json.modify_request(request_builder)
-    assert not callable(request_builder.return_type)
+    assert callable(request_builder.return_type)
+    assert request_builder.return_type(mock_response) == mock_response.json()
+
+
+def test_returns_json_builtin_type(request_builder, mocker):
+    mock_response = mocker.Mock()
+    mock_response.json.return_value = {"key": "1"}
+    request_builder.get_converter.return_value = None
+    returns_json = returns.json(type=int, key="key")
+    request_builder.return_type = returns.ReturnType.with_decorator(
+        None, returns_json
+    )
+    returns_json.modify_request(request_builder)
+    print(request_builder.return_type)
+    assert callable(request_builder.return_type)
+    assert request_builder.return_type(mock_response) == 1
+
+
+class TestReturnsJsonCast(object):
+    default_value = {"key": "1"}
+
+    @staticmethod
+    def prepare_test(request_builder, mocker, value=default_value, **kwargs):
+        mock_response = mocker.Mock()
+        mock_response.json.return_value = value
+        request_builder.get_converter.return_value = None
+        returns_json = returns.json(**kwargs)
+        request_builder.return_type = returns.ReturnType.with_decorator(
+            None, returns_json
+        )
+        returns_json.modify_request(request_builder)
+        return mock_response
+
+    def test_without_cast(self, request_builder, mocker):
+        mock_response = self.prepare_test(
+            request_builder, mocker, type=int, key="key", cast=False
+        )
+        assert request_builder.return_type(mock_response) == "1"
+
+    def test_with_cast(self, request_builder, mocker):
+        mock_response = self.prepare_test(
+            request_builder, mocker, type=lambda _: "test", cast=True
+        )
+        assert request_builder.return_type(mock_response) == "test"
+
+    def test_with_builtin_type(self, request_builder, mocker):
+        mock_response = self.prepare_test(request_builder, mocker, type=str)
+        assert request_builder.return_type(mock_response) == str(
+            self.default_value
+        )
+
+    def test_with_builtin_type_and_key(self, request_builder, mocker):
+        mock_response = self.prepare_test(
+            request_builder, mocker, key="key", type=int
+        )
+        assert request_builder.return_type(mock_response) == 1
+
+    def test_with_not_callable_cast(self, request_builder, mocker):
+        with pytest.raises(ValueError):
+            self.prepare_test(request_builder, mocker, type=1, cast=True)
 
 
 def test_returns_JsonStrategy(mocker):

--- a/uplink/returns.py
+++ b/uplink/returns.py
@@ -66,11 +66,13 @@ class _ReturnsBase(decorators.MethodAnnotation):
             return
 
         converter = self._get_converter(request_builder, return_type)
-        if converter is not None:
-            # Found a converter that can handle the return type.
-            request_builder.return_type = return_type.with_strategy(
-                self._make_strategy(converter)
-            )
+        if converter is None:
+            return
+
+        # Found a converter that can handle the return type.
+        request_builder.return_type = return_type.with_strategy(
+            self._make_strategy(converter)
+        )
 
 
 class JsonStrategy(object):


### PR DESCRIPTION
Fix ``@returns.json`` to cast JSON response (or field referenced by the ``key`` argument) using the ``type`` argument when the given type is callable. This restores behavior that was inadvertently changed in v0.9.3.

Example:

```python
  @uplink.returns.from_json(key=("data", 0, "size"), type=int)
  @uplink.get("/users/{user}/repos")
  def get_first_repo_size(self, user):
      pass
```

```python
assert github.get_first_repo_size("prkumar") == 300
```

#215
