### PR TITLE
Add `RetryBackoff` to support custom @retry backoff strategies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,5 @@ Pipfile.lock
 # macOS
 .DS_Store
 
+# VS Code
+.vscode/

--- a/docs/source/dev/decorators.rst
+++ b/docs/source/dev/decorators.rst
@@ -150,6 +150,23 @@ to specify one of the alternative approaches exposed through the
         def get_user(self, user):
             """Get user by username."""
 
+You can implement a custom backoff strategy by extending the class
+:class:`uplink.retry.RetryBackoff`:
+
+.. code-block:: python
+   :emphasize-lines: 3,7
+
+    from uplink.retry import RetryBackoff
+
+    class MyCustomBackoff(RetryBackoff):
+        ...
+
+    class GitHub(uplink.Consumer):
+        @uplink.retry(backoff=MyCustomBackoff())
+        @uplink.get("/users/{user}")
+        def get_user(self, user):
+            pass
+
 .. automodule:: uplink.retry.backoff
     :members:
 

--- a/tests/integration/test_retry.py
+++ b/tests/integration/test_retry.py
@@ -29,7 +29,9 @@ class GitHub(Consumer):
     def get_issue(self, user, repo, issue):
         pass
 
-    @retry(max_attempts=3, on_exception=retry.CONNECTION_TIMEOUT)
+    @retry(
+        stop=retry.stop.after_attempt(3), on_exception=retry.CONNECTION_TIMEOUT
+    )
     @get("repos/{user}/{repo}/project/{project}")
     def get_project(self, user, repo, project):
         pass

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -75,22 +75,6 @@ def test_stop_or_with_none():
     assert stop1 is (stop1 | None)
 
 
-def test_retry_custom_stop():
-    def custom_stop(*_):
-        return True
-
-    decorator = retry(stop=custom_stop)
-    assert decorator._stop == custom_stop
-
-
-def test_retry_backoff():
-    def custom_backoff(*_):
-        return True
-
-    decorator = retry(backoff=custom_backoff)
-    assert decorator._backoff == custom_backoff
-
-
 def test_retry_decorator_exposes_submodules_as_properties():
     assert retry.backoff is backoff
     assert retry.stop is stop

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -38,8 +38,8 @@ def test_fixed_backoff():
 def test_compose_backoff(mocker):
     left = backoff.from_iterable([0, 1])
     right = backoff.from_iterable([2])
-    left_after_stop = mocker.spy(left, "after_stop")
-    right_after_stop = mocker.spy(right, "after_stop")
+    mocker.spy(left, "after_stop")
+    mocker.spy(right, "after_stop")
     strategy = left | right
 
     # Should return None after both strategies are exhausted
@@ -51,8 +51,8 @@ def test_compose_backoff(mocker):
     # Should invoke both strategies after_stop method
     strategy.after_stop()
 
-    left_after_stop.assert_called_once()
-    right_after_stop.assert_called_once()
+    left.after_stop.assert_called_once_with()
+    right.after_stop.assert_called_once_with()
 
 
 def test_retry_stop_default():

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -38,21 +38,21 @@ def test_fixed_backoff():
 def test_compose_backoff(mocker):
     left = backoff.from_iterable([0, 1])
     right = backoff.from_iterable([2])
-    mocker.spy(left, "after_stop")
-    mocker.spy(right, "after_stop")
+    mocker.spy(left, "handle_after_final_retry")
+    mocker.spy(right, "handle_after_final_retry")
     strategy = left | right
 
     # Should return None after both strategies are exhausted
-    assert strategy.after_response(None, None) == 0
-    assert strategy.after_exception(None, None, None, None) == 1
-    assert strategy.after_response(None, None) == 2
-    assert strategy.after_exception(None, None, None, None) is None
+    assert strategy.get_timeout_after_response(None, None) == 0
+    assert strategy.get_timeout_after_exception(None, None, None, None) == 1
+    assert strategy.get_timeout_after_response(None, None) == 2
+    assert strategy.get_timeout_after_exception(None, None, None, None) is None
 
     # Should invoke both strategies after_stop method
-    strategy.after_stop()
+    strategy.handle_after_final_retry()
 
-    left.after_stop.assert_called_once_with()
-    right.after_stop.assert_called_once_with()
+    left.handle_after_final_retry.assert_called_once_with()
+    right.handle_after_final_retry.assert_called_once_with()
 
 
 def test_retry_stop_default():

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -38,8 +38,8 @@ def test_fixed_backoff():
 def test_compose_backoff(mocker):
     left = backoff.from_iterable([0, 1])
     right = backoff.from_iterable([2])
-    mocker.spy(left, "after_stop")
-    mocker.spy(right, "after_stop")
+    left_after_stop = mocker.spy(left, "after_stop")
+    right_after_stop = mocker.spy(right, "after_stop")
     strategy = left | right
 
     # Should return None after both strategies are exhausted
@@ -51,8 +51,8 @@ def test_compose_backoff(mocker):
     # Should invoke both strategies after_stop method
     strategy.after_stop()
 
-    left.after_stop.assert_called_once()
-    right.after_stop.assert_called_once()
+    left_after_stop.assert_called_once()
+    right_after_stop.assert_called_once()
 
 
 def test_retry_stop_default():

--- a/uplink/retry/__init__.py
+++ b/uplink/retry/__init__.py
@@ -1,4 +1,5 @@
 from uplink.retry.retry import retry
 from uplink.retry.when import RetryPredicate
+from uplink.retry.backoff import RetryBackoff
 
-__all__ = ["retry", "RetryPredicate"]
+__all__ = ["retry", "RetryPredicate", "RetryBackoff"]

--- a/uplink/retry/backoff.py
+++ b/uplink/retry/backoff.py
@@ -8,6 +8,29 @@ MAX_VALUE = sys.maxsize / 2
 __all__ = ["jittered", "exponential", "fixed"]
 
 
+def from_iterable(iterable):
+    """Creates a retry strategy from an iterable of timeouts"""
+
+    class IterableRetryBackoff(_IterableBackoff):
+        def __iter__(self):
+            return iter(iterable)
+
+    return IterableRetryBackoff()
+
+
+def from_iterable_factory(iterable_factory):
+    """
+    Creates a retry strategy from a function that returns an iterable
+    of timeouts.
+    """
+
+    class IterableRetryBackoff(_IterableBackoff):
+        def __iter__(self):
+            return iter(iterable_factory())
+
+    return IterableRetryBackoff()
+
+
 class RetryBackoff(object):
     """
     Base class for strategies that calculate the amount of time to wait
@@ -37,13 +60,48 @@ class RetryBackoff(object):
         """
         pass  # pragma: no cover
 
+    def __or__(self, other):
+        """
+        Composes the current strategy with another.
 
-class IterableBackoff(RetryBackoff):
-    """
-    Base class for creating retry strategies from an iterable that
-    emits an ordered sequence of timeouts.
-    """
+        The resulting strategy will use the timeout computed by the
+        current strategy if it not ``None``. Otherwise, it will
+        try to fallback on the timeout computed by the other strategy.
+        If both return ``None``, the composite stratey will also return
+        ``None``.
+        """
+        assert isinstance(
+            other, RetryBackoff
+        ), "Both objects should be backoffs."
 
+        return _Or(self, other)
+
+
+class _Or(RetryBackoff):
+    def __init__(self, left, right):
+        self._left = left
+        self._right = right
+
+    def after_response(self, request, response):
+        delay = self._left.after_response(request, response)
+        if delay is None:
+            return self._right.after_response(request, response)
+        return delay
+
+    def after_exception(self, request, exc_type, exc_val, exc_tb):
+        delay = self._left.after_exception(request, exc_type, exc_val, exc_tb)
+        if delay is None:
+            return self._right.after_exception(
+                request, exc_type, exc_val, exc_tb
+            )
+        return delay
+
+    def after_stop(self):
+        self._left.after_stop()
+        self._right.after_stop()
+
+
+class _IterableBackoff(RetryBackoff):
     __iterator = None
 
     def __iter__(self):
@@ -71,7 +129,7 @@ class IterableBackoff(RetryBackoff):
         self.__iterator = None
 
 
-class jittered(IterableBackoff):
+class jittered(_IterableBackoff):
     def __init__(self, base=2, multiplier=1, minimum=0, maximum=MAX_VALUE):
         """
         Waits using capped exponential backoff and full jitter.
@@ -88,7 +146,7 @@ class jittered(IterableBackoff):
         return (random.uniform(0, 1) * delay for delay in self._exp_backoff())
 
 
-class exponential(IterableBackoff):
+class exponential(_IterableBackoff):
     def __init__(self, base=2, multiplier=1, minimum=0, maximum=MAX_VALUE):
         """
         Waits using capped exponential backoff, meaning that the delay
@@ -109,7 +167,7 @@ class exponential(IterableBackoff):
             delay *= self._base
 
 
-class fixed(IterableBackoff):
+class fixed(_IterableBackoff):
     def __init__(self, seconds):
         """Waits for a fixed number of ``seconds`` before each retry."""
         self._seconds = seconds

--- a/uplink/retry/backoff.py
+++ b/uplink/retry/backoff.py
@@ -8,45 +8,77 @@ MAX_VALUE = sys.maxsize / 2
 __all__ = ["jittered", "exponential", "fixed"]
 
 
-def jittered(base=2, multiplier=1, minimum=0, maximum=MAX_VALUE):
-    """
-    Waits using capped exponential backoff and full jitter.
+class RetryBackoff(object):
+    def after_response(self, request, response):
+        raise NotImplementedError  # pragma: no cover
 
-    The implementation is discussed in `this AWS Architecture Blog
-    post <https://amzn.to/2xc2nK2>`_, which recommends this approach
-    for any remote clients, as it minimizes the total completion
-    time of competing clients in a distributed system experiencing
-    high contention.
-    """
-    exp_backoff = exponential(base, multiplier, minimum, maximum)
-    return lambda *_: iter(
-        random.uniform(0, 1) * delay for delay in exp_backoff()
-    )  # pragma: no cover
+    def after_exception(self, request, exc_type, exc_val, exc_tb):
+        raise NotImplementedError  # pragma: no cover
+
+    def after_stop(self):
+        pass  # pragma: no cover
 
 
-def exponential(base=2, multiplier=1, minimum=0, maximum=MAX_VALUE):
-    """
-    Waits using capped exponential backoff, meaning that the delay
-    is multiplied by a constant ``base`` after each attempt, up to
-    an optional ``maximum`` value.
-    """
+class IterableBackoff(RetryBackoff):
+    def __init__(self):
+        self.__iterator = None
 
-    def wait_iterator():
-        delay = multiplier
-        while minimum > delay:
-            delay *= base
+    def __iter__(self):
+        raise NotImplementedError  # pragma: no cover
+
+    def __call__(self):
+        return iter(self)
+
+    def __next(self):
+        if self.__iterator is None:
+            self.__iterator = iter(self)
+
+        try:
+            return next(self.__iterator)
+        except StopIteration:
+            return None
+
+    def after_response(self, request, response):
+        return self.__next()
+
+    def after_exception(self, request, exc_type, exc_val, exc_tb):
+        return self.__next()
+
+    def after_stop(self):
+        self.__iterator = None
+
+
+class jittered(IterableBackoff):
+    def __init__(self, base=2, multiplier=1, minimum=0, maximum=MAX_VALUE):
+        super().__init__()
+        self._exp_backoff = exponential(base, multiplier, minimum, maximum)
+
+    def __iter__(self):
+        return (random.uniform(0, 1) * delay for delay in self._exp_backoff())
+
+
+class exponential(IterableBackoff):
+    def __init__(self, base=2, multiplier=1, minimum=0, maximum=MAX_VALUE):
+        super().__init__()
+        self._base = base
+        self._multiplier = multiplier
+        self._minimum = minimum
+        self._maximum = maximum
+
+    def __iter__(self):
+        delay = self._multiplier
+        while self._minimum > delay:
+            delay *= self._base
         while True:
-            yield min(delay, maximum)
-            delay *= base
-
-    return wait_iterator
+            yield min(delay, self._maximum)
+            delay *= self._base
 
 
-def fixed(seconds):
-    """Waits for a fixed number of ``seconds`` before each retry."""
+class fixed(IterableBackoff):
+    def __init__(self, seconds):
+        super().__init__()
+        self._seconds = seconds
 
-    def wait_iterator():
+    def __iter__(self):
         while True:
-            yield seconds
-
-    return wait_iterator
+            yield self._seconds

--- a/uplink/retry/backoff.py
+++ b/uplink/retry/backoff.py
@@ -9,17 +9,41 @@ __all__ = ["jittered", "exponential", "fixed"]
 
 
 class RetryBackoff(object):
+    """
+    Base class for strategies that calculate the amount of time to wait
+    between retry attempts.
+    """
+
     def after_response(self, request, response):
+        """
+        Returns the number of seconds to wait before retrying the
+        request, or None to indicate that the given response should
+        be returned.
+        """
         raise NotImplementedError  # pragma: no cover
 
     def after_exception(self, request, exc_type, exc_val, exc_tb):
+        """
+        Returns the number of seconds to wait before retrying the
+        request, or None to indicate that the given exception should be
+        raised.
+        """
         raise NotImplementedError  # pragma: no cover
 
     def after_stop(self):
+        """
+        Handles any clean-up necessary following the final retry
+        attempt.
+        """
         pass  # pragma: no cover
 
 
 class IterableBackoff(RetryBackoff):
+    """
+    Base class for creating retry strategies from an iterable that
+    emits an ordered sequence of timeouts.
+    """
+
     def __init__(self):
         self.__iterator = None
 
@@ -50,6 +74,15 @@ class IterableBackoff(RetryBackoff):
 
 class jittered(IterableBackoff):
     def __init__(self, base=2, multiplier=1, minimum=0, maximum=MAX_VALUE):
+        """
+        Waits using capped exponential backoff and full jitter.
+
+        The implementation is discussed in `this AWS Architecture Blog
+        post <https://amzn.to/2xc2nK2>`_, which recommends this approach
+        for any remote clients, as it minimizes the total completion
+        time of competing clients in a distributed system experiencing
+        high contention.
+        """
         super().__init__()
         self._exp_backoff = exponential(base, multiplier, minimum, maximum)
 
@@ -59,6 +92,11 @@ class jittered(IterableBackoff):
 
 class exponential(IterableBackoff):
     def __init__(self, base=2, multiplier=1, minimum=0, maximum=MAX_VALUE):
+        """
+        Waits using capped exponential backoff, meaning that the delay
+        is multiplied by a constant ``base`` after each attempt, up to
+        an optional ``maximum`` value.
+        """
         super().__init__()
         self._base = base
         self._multiplier = multiplier
@@ -76,6 +114,7 @@ class exponential(IterableBackoff):
 
 class fixed(IterableBackoff):
     def __init__(self, seconds):
+        """Waits for a fixed number of ``seconds`` before each retry."""
         super().__init__()
         self._seconds = seconds
 

--- a/uplink/retry/backoff.py
+++ b/uplink/retry/backoff.py
@@ -44,8 +44,7 @@ class IterableBackoff(RetryBackoff):
     emits an ordered sequence of timeouts.
     """
 
-    def __init__(self):
-        self.__iterator = None
+    __iterator = None
 
     def __iter__(self):
         raise NotImplementedError  # pragma: no cover
@@ -83,7 +82,6 @@ class jittered(IterableBackoff):
         time of competing clients in a distributed system experiencing
         high contention.
         """
-        super().__init__()
         self._exp_backoff = exponential(base, multiplier, minimum, maximum)
 
     def __iter__(self):
@@ -97,7 +95,6 @@ class exponential(IterableBackoff):
         is multiplied by a constant ``base`` after each attempt, up to
         an optional ``maximum`` value.
         """
-        super().__init__()
         self._base = base
         self._multiplier = multiplier
         self._minimum = minimum
@@ -115,7 +112,6 @@ class exponential(IterableBackoff):
 class fixed(IterableBackoff):
     def __init__(self, seconds):
         """Waits for a fixed number of ``seconds`` before each retry."""
-        super().__init__()
         self._seconds = seconds
 
     def __iter__(self):

--- a/uplink/retry/backoff.py
+++ b/uplink/retry/backoff.py
@@ -144,7 +144,9 @@ class jittered(_IterableBackoff):
         self._exp_backoff = exponential(base, multiplier, minimum, maximum)
 
     def __iter__(self):
-        return (random.uniform(0, 1) * delay for delay in self._exp_backoff())
+        return (
+            random.uniform(0, 1) * delay for delay in self._exp_backoff()
+        )  # pragma: no branch
 
 
 class exponential(_IterableBackoff):

--- a/uplink/retry/backoff.py
+++ b/uplink/retry/backoff.py
@@ -42,16 +42,16 @@ class RetryBackoff(object):
         CustomBackoffA() | CustomBackoffB()
 
     The resulting backoff strategy will first compute the timeout using
-    the left-hand instance. If that timeout is None, the strategy will
-    try to compute a fallback using the right-hand instance. If both
-    instances return ``None``, the resulting strategy will also return
-    ``None``.
+    the left-hand instance. If that timeout is ``None``, the strategy
+    will try to compute a fallback using the right-hand instance. If
+    both instances return ``None``, the resulting strategy will also
+    return ``None``.
     """
 
     def after_response(self, request, response):
         """
         Returns the number of seconds to wait before retrying the
-        request, or None to indicate that the given response should
+        request, or ``None`` to indicate that the given response should
         be returned.
         """
         raise NotImplementedError  # pragma: no cover
@@ -59,8 +59,8 @@ class RetryBackoff(object):
     def after_exception(self, request, exc_type, exc_val, exc_tb):
         """
         Returns the number of seconds to wait before retrying the
-        request, or None to indicate that the given exception should be
-        raised.
+        request, or ``None`` to indicate that the given exception
+        should be raised.
         """
         raise NotImplementedError  # pragma: no cover
 

--- a/uplink/retry/backoff.py
+++ b/uplink/retry/backoff.py
@@ -44,7 +44,7 @@ class RetryBackoff(object):
     The resulting backoff strategy will first compute the timeout using
     the left-hand instance. If that timeout is None, the strategy will
     try to compute a fallback using the right-hand instance. If both
-    instances return ``None``, the composite strategy will also return
+    instances return ``None``, the resulting strategy will also return
     ``None``.
     """
 
@@ -72,19 +72,10 @@ class RetryBackoff(object):
         pass  # pragma: no cover
 
     def __or__(self, other):
-        """
-        Composes the current strategy with another.
-
-        The resulting strategy will use the timeout computed by the
-        current strategy if it not ``None``. Otherwise, it will
-        try to fallback on the timeout computed by the other strategy.
-        If both return ``None``, the composite stratey will also return
-        ``None``.
-        """
+        """Composes the current strategy with another."""
         assert isinstance(
             other, RetryBackoff
         ), "Both objects should be backoffs."
-
         return _Or(self, other)
 
 

--- a/uplink/retry/backoff.py
+++ b/uplink/retry/backoff.py
@@ -33,8 +33,19 @@ def from_iterable_factory(iterable_factory):
 
 class RetryBackoff(object):
     """
-    Base class for strategies that calculate the amount of time to wait
-    between retry attempts.
+    Base class for a strategy that calculates the timeout between
+    retry attempts.
+
+    You can compose two ``RetryBackoff`` instances by using the ``|``
+    operator::
+
+        CustomBackoffA() | CustomBackoffB()
+
+    The resulting backoff strategy will first compute the timeout using
+    the left-hand instance. If that timeout is None, the strategy will
+    try to compute a fallback using the right-hand instance. If both
+    instances return ``None``, the composite strategy will also return
+    ``None``.
     """
 
     def after_response(self, request, response):

--- a/uplink/retry/backoff.py
+++ b/uplink/retry/backoff.py
@@ -130,16 +130,17 @@ class _IterableBackoff(RetryBackoff):
 
 
 class jittered(_IterableBackoff):
-    def __init__(self, base=2, multiplier=1, minimum=0, maximum=MAX_VALUE):
-        """
-        Waits using capped exponential backoff and full jitter.
+    """
+    Waits using capped exponential backoff and full jitter.
 
-        The implementation is discussed in `this AWS Architecture Blog
-        post <https://amzn.to/2xc2nK2>`_, which recommends this approach
-        for any remote clients, as it minimizes the total completion
-        time of competing clients in a distributed system experiencing
-        high contention.
-        """
+    The implementation is discussed in `this AWS Architecture Blog
+    post <https://amzn.to/2xc2nK2>`_, which recommends this approach
+    for any remote clients, as it minimizes the total completion
+    time of competing clients in a distributed system experiencing
+    high contention.
+    """
+
+    def __init__(self, base=2, multiplier=1, minimum=0, maximum=MAX_VALUE):
         self._exp_backoff = exponential(base, multiplier, minimum, maximum)
 
     def __iter__(self):
@@ -147,12 +148,13 @@ class jittered(_IterableBackoff):
 
 
 class exponential(_IterableBackoff):
+    """
+    Waits using capped exponential backoff, meaning that the delay
+    is multiplied by a constant ``base`` after each attempt, up to
+    an optional ``maximum`` value.
+    """
+
     def __init__(self, base=2, multiplier=1, minimum=0, maximum=MAX_VALUE):
-        """
-        Waits using capped exponential backoff, meaning that the delay
-        is multiplied by a constant ``base`` after each attempt, up to
-        an optional ``maximum`` value.
-        """
         self._base = base
         self._multiplier = multiplier
         self._minimum = minimum
@@ -168,8 +170,9 @@ class exponential(_IterableBackoff):
 
 
 class fixed(_IterableBackoff):
+    """Waits for a fixed number of ``seconds`` before each retry."""
+
     def __init__(self, seconds):
-        """Waits for a fixed number of ``seconds`` before each retry."""
         self._seconds = seconds
 
     def __iter__(self):

--- a/uplink/retry/backoff.py
+++ b/uplink/retry/backoff.py
@@ -144,9 +144,8 @@ class jittered(_IterableBackoff):
         self._exp_backoff = exponential(base, multiplier, minimum, maximum)
 
     def __iter__(self):
-        return (
-            random.uniform(0, 1) * delay for delay in self._exp_backoff()
-        )  # pragma: no branch
+        for delay in self._exp_backoff():  # pragma: no branch
+            yield random.uniform(0, 1) * delay
 
 
 class exponential(_IterableBackoff):

--- a/uplink/retry/retry.py
+++ b/uplink/retry/retry.py
@@ -6,7 +6,7 @@ from uplink.retry import (
     stop as stop_mod,
     backoff as backoff_mod,
 )
-from uplink.retry.backoff import RetryBackoff, IterableBackoff
+from uplink.retry.backoff import RetryBackoff
 from uplink.retry._helpers import ClientExceptionProxy
 
 __all__ = ["retry"]
@@ -90,7 +90,7 @@ class retry(decorators.MethodAnnotation):
             backoff = backoff_mod.jittered()
 
         if not isinstance(backoff, backoff_mod.RetryBackoff):
-            backoff = _CustomIterableBackoff(backoff)
+            backoff = backoff_mod.from_iterable_factory(backoff)
 
         self._when = when
         self._backoff = backoff
@@ -114,14 +114,6 @@ class retry(decorators.MethodAnnotation):
                 )
             )
         )
-
-
-class _CustomIterableBackoff(IterableBackoff):
-    def __init__(self, iterator_func):
-        self.__iterator_func = iterator_func
-
-    def __iter__(self):
-        return self.__iterator_func()
 
 
 class _RetryStrategy(RetryBackoff):

--- a/uplink/retry/retry.py
+++ b/uplink/retry/retry.py
@@ -8,41 +8,7 @@ from uplink.retry import (
 )
 from uplink.retry._helpers import ClientExceptionProxy
 
-__all__ = ["retry"]
-
-
-class RetryTemplate(RequestTemplate):
-    def __init__(self, backoff, retry_condition):
-        self._backoff = backoff
-        self._backoff_iterator = None
-        self._condition = retry_condition
-        self._reset()
-
-    def _next_delay(self):
-        try:
-            delay = next(self._backoff_iterator)
-        except StopIteration:
-            # Fallback to the default behavior
-            pass
-        else:
-            return transitions.sleep(delay)
-
-    def _reset(self):
-        self._backoff_iterator = self._backoff()
-
-    def after_response(self, request, response):
-        if self._condition.should_retry_after_response(response):
-            return self._next_delay()
-        else:
-            self._reset()
-
-    def after_exception(self, request, exc_type, exc_val, exc_tb):
-        if self._condition.should_retry_after_exception(
-            exc_type, exc_val, exc_tb
-        ):
-            return self._next_delay()
-        else:
-            self._reset()
+__all__ = ["retry", "RetryBackoff"]
 
 
 # noinspection PyPep8Naming
@@ -94,6 +60,10 @@ class retry(decorators.MethodAnnotation):
 
     _DEFAULT_PREDICATE = when_mod.raises(Exception)
 
+    stop = stop_mod
+    backoff = backoff_mod
+    when = when_mod
+
     def __init__(
         self,
         when=None,
@@ -102,22 +72,27 @@ class retry(decorators.MethodAnnotation):
         stop=None,
         backoff=None,
     ):
-        if stop is not None:
-            self._stop = stop
-        elif max_attempts is not None:
-            self._stop = stop_mod.after_attempt(max_attempts)
-        else:
-            self._stop = stop_mod.NEVER
-
-        self._predicate = when
+        if stop is None:
+            if max_attempts is not None:
+                stop = stop_mod.after_attempt(max_attempts)
+            else:
+                stop = stop_mod.NEVER
 
         if on_exception is not None:
-            self._predicate = when_mod.raises(on_exception) | self._predicate
+            when = when_mod.raises(on_exception) | when
 
-        if self._predicate is None:
-            self._predicate = self._DEFAULT_PREDICATE
+        if when is None:
+            when = self._DEFAULT_PREDICATE
 
-        self._backoff = backoff_mod.jittered() if backoff is None else backoff
+        if backoff is None:
+            backoff = backoff_mod.jittered()
+
+        if not isinstance(backoff, RetryBackoff):
+            backoff = _IterativeBackoff(backoff)
+
+        self._when = when
+        self._backoff = backoff
+        self._stop = stop
 
     BASE_CLIENT_EXCEPTION = ClientExceptionProxy(
         lambda ex: ex.BaseClientException
@@ -129,22 +104,102 @@ class retry(decorators.MethodAnnotation):
 
     def modify_request(self, request_builder):
         request_builder.add_request_template(
-            self._create_template(request_builder)
+            _RetryTemplate(
+                _RetryStrategy(
+                    self._when(request_builder),
+                    self._backoff,
+                    self._stop,
+                )
+            )
         )
 
-    def _create_template(self, request_builder):
-        return RetryTemplate(
-            self._backoff_iterator, self._predicate(request_builder)
+
+class RetryBackoff(object):
+    def after_response(self, request, response):
+        raise NotImplementedError
+
+    def after_exception(self, request, exc_type, exc_val, exc_tb):
+        raise NotImplementedError
+
+    def after_stop(self):
+        pass
+
+
+class _IterativeBackoff(RetryBackoff):
+    def __init__(self, iterator_func):
+        self._iterator_func = iterator_func
+        self._iterator = iterator_func()
+
+    def _next(self):
+        try:
+            return next(self._iterator)
+        except StopIteration:
+            return None
+
+    def after_response(self, request, response):
+        return self._next()
+
+    def after_exception(self, request, exc_type, exc_val, exc_tb):
+        return self._next()
+
+    def after_stop(self):
+        self._iterator = self._iterator_func()
+
+
+class _RetryStrategy(RetryBackoff):
+    def __init__(self, condition, backoff, stop):
+        self._condition = condition
+        self._backoff = backoff
+        self._stop = stop
+        self._stop_iter = self._stop()
+
+    def _process_delay(self, delay):
+        next(self._stop_iter)
+        if self._stop_iter.send(delay):
+            return None
+        return delay
+
+    def after_response(self, request, response):
+        if not self._condition.should_retry_after_response(response):
+            return None
+
+        delay = self._backoff.after_response(request, response)
+        return self._process_delay(delay)
+
+    def after_exception(self, request, exc_type, exc_val, exc_tb):
+        if not self._condition.should_retry_after_exception(
+            exc_type, exc_val, exc_tb
+        ):
+            return None
+
+        delay = self._backoff.after_exception(
+            request, exc_type, exc_val, exc_tb
         )
+        return self._process_delay(delay)
 
-    def _backoff_iterator(self):
-        stop_gen = self._stop()
-        for delay in self._backoff():
-            next(stop_gen)
-            if stop_gen.send(delay):
-                break
-            yield delay
+    def after_stop(self):
+        self._backoff.after_stop()
+        self._stop_iter = self._stop()
 
-    stop = stop_mod
-    backoff = backoff_mod
-    when = when_mod
+
+class _RetryTemplate(RequestTemplate):
+    def __init__(self, strategy):
+        self._strategy = strategy
+
+    def after_response(self, request, response):
+        delay = self._strategy.after_response(request, response)
+        if delay is None:
+            self._strategy.after_stop()
+            return
+
+        return transitions.sleep(delay)
+
+    def after_exception(self, request, exc_type, exc_val, exc_tb):
+        delay = self._strategy.after_exception(
+            request, exc_type, exc_val, exc_tb
+        )
+        if delay is None:
+            self._strategy.after_stop()
+            return
+
+        return transitions.sleep(delay)

--- a/uplink/retry/retry.py
+++ b/uplink/retry/retry.py
@@ -6,6 +6,7 @@ from uplink.retry import (
     stop as stop_mod,
     backoff as backoff_mod,
 )
+from uplink.retry.backoff import RetryBackoff, IterableBackoff
 from uplink.retry._helpers import ClientExceptionProxy
 
 __all__ = ["retry"]
@@ -53,9 +54,10 @@ class retry(decorators.MethodAnnotation):
             that should prompt a retry attempt.
         stop (:obj:`callable`, optional): A function that creates
             predicates that decide when to stop retrying a request.
-        backoff (:obj:`callable`, optional): A function that creates
-            an iterator over the ordered sequence of timeouts between
-            retries. If not specified, exponential backoff is used.
+        backoff (:class:`RetryBackoff`, :obj:`callable`, optional): A
+            backoff strategy or a function that creates an iterator
+            over the ordered sequence of timeouts between retries. If
+            not specified, exponential backoff is used.
     """
 
     _DEFAULT_PREDICATE = when_mod.raises(Exception)
@@ -114,7 +116,7 @@ class retry(decorators.MethodAnnotation):
         )
 
 
-class _CustomIterableBackoff(backoff_mod.IterableBackoff):
+class _CustomIterableBackoff(IterableBackoff):
     def __init__(self, iterator_func):
         super().__init__()
         self.__iterator_func = iterator_func
@@ -123,7 +125,7 @@ class _CustomIterableBackoff(backoff_mod.IterableBackoff):
         return self.__iterator_func()
 
 
-class _RetryStrategy(backoff_mod.RetryBackoff):
+class _RetryStrategy(RetryBackoff):
     def __init__(self, condition, backoff, stop):
         self._condition = condition
         self._backoff = backoff

--- a/uplink/retry/retry.py
+++ b/uplink/retry/retry.py
@@ -118,7 +118,6 @@ class retry(decorators.MethodAnnotation):
 
 class _CustomIterableBackoff(IterableBackoff):
     def __init__(self, iterator_func):
-        super().__init__()
         self.__iterator_func = iterator_func
 
     def __iter__(self):


### PR DESCRIPTION
Add a new base class, `uplink.retry.RetryBackoff`, which can be extended to implement custom backoff strategies. Subclasses can override three methods:

- `get_timeout_after_response(request, response)`: Returns the number of seconds to wait before retrying the request, or ``None`` to indicate that the given response should be returned.
- `get_timeout_after_exception(request, exc_type, exc_val, exc_tb)`: Returns the number of seconds to wait before retrying the request, or ``None`` to indicate that the given exception should be raised.
- `handle_after_final_retry()`: Handles any clean-up necessary following the final retry attempt.

An instance of a `RetryBackoff` subclass can be provided through the `backoff` argument of the `@retry` decorator.

#238