### PR TITLE
Fix asynchronous callback wrapping

### DIFF
--- a/tests/unit/test_aiohttp_client.py
+++ b/tests/unit/test_aiohttp_client.py
@@ -148,6 +148,15 @@ class TestAiohttp(object):
         assert value == 1
         assert response.text.called
 
+        # Run: Asynchronous callback
+        async def callback(*_):
+            return 2
+
+        new_callback = aiohttp_.threaded_callback(callback)
+        value = await new_callback(response)
+        assert value == 2
+        assert response.text.called
+
         # Run: Verify with response that is not ClientResponse (should not be wrapped)
         response = mocker.Mock()
         await new_callback(response)

--- a/uplink/clients/aiohttp_.py
+++ b/uplink/clients/aiohttp_.py
@@ -24,6 +24,8 @@ def threaded_callback(callback):
             await response.text()
             response = ThreadedResponse(response)
         response = callback(response)
+        if asyncio.iscoroutine(response):
+            response = await response
         if isinstance(response, ThreadedResponse):
             return response.unwrap()
         else:


### PR DESCRIPTION
Fixes #256.

Changes proposed in this pull request:
- Fix `threaded_callback` to work with async callbacks. This restores behavior that was changed in v0.9.6 ([#248](https://github.com/prkumar/uplink/pull/248)).

Attention: @prkumar