### PR TITLE
Do not wrap async function with threaded_callback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog`_, and this project adheres to the
 `Semantic Versioning`_ scheme.
 
+Unreleased
+==========
+Fixed
+-----
+- Fix behavior of async ``@response_handler`` with ``AiohttpClient``. (`#256`_)
+
 0.9.6_ - 2022-01-24
 ===================
 Added

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ if sys.version_info.major < 3:
     collect_ignore.extend(
         [
             "unit/test_aiohttp_client.py",
+            "integration/test_handlers_aiohttp.py",
             "integration/test_retry_aiohttp.py",
         ]
     )

--- a/tests/integration/test_handlers_aiohttp.py
+++ b/tests/integration/test_handlers_aiohttp.py
@@ -8,6 +8,7 @@ from uplink.clients.aiohttp_ import AiohttpClient
 
 # Constants
 BASE_URL = "https://example.com/"
+SIMPLE_RESPONSE = "simple response"
 
 
 @pytest.fixture
@@ -17,7 +18,7 @@ def mock_aiohttp_session(mocker):
 
 @uplink.response_handler
 async def simple_async_handler(response):
-    return response
+    return SIMPLE_RESPONSE
 
 
 class Calendar(uplink.Consumer):
@@ -44,4 +45,4 @@ async def test_simple_async_handler(mock_aiohttp_session, mock_response):
     response = await calendar.get_todo(todo_id=1)
 
     # Verify
-    assert response == mock_response
+    assert response == SIMPLE_RESPONSE

--- a/tests/integration/test_handlers_aiohttp.py
+++ b/tests/integration/test_handlers_aiohttp.py
@@ -1,0 +1,47 @@
+# Local imports.
+import uplink
+
+# Third-party imports
+import aiohttp
+import pytest
+from uplink.clients.aiohttp_ import AiohttpClient
+
+# Constants
+BASE_URL = "https://example.com/"
+
+
+@pytest.fixture
+def mock_aiohttp_session(mocker):
+    return mocker.Mock(spec=aiohttp.ClientSession)
+
+
+@uplink.response_handler
+async def simple_async_handler(response):
+    return response
+
+
+class Calendar(uplink.Consumer):
+    @simple_async_handler
+    @uplink.get("todos/{todo_id}")
+    def get_todo(self, todo_id):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_simple_async_handler(mock_aiohttp_session, mock_response):
+    mock_response.status = 200
+
+    async def request(*args, **kwargs):
+        return mock_response
+
+    mock_aiohttp_session.request = request
+
+    calendar = Calendar(
+        base_url=BASE_URL, client=AiohttpClient(mock_aiohttp_session)
+    )
+
+    # Run
+    response = await calendar.get_todo(todo_id=1)
+
+    # Verify
+    assert response == mock_response

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -16,7 +16,7 @@ class TestResponseHandler(object):
 
 class TestRequestAuditor(object):
     def test_audit_request(self, mocker):
-        auditor = mocker.stub()
+        auditor = mocker.Mock()
         ra = hooks.RequestAuditor(auditor)
         ra.audit_request("consumer", "request")
         auditor.assert_called_with("request")
@@ -24,7 +24,7 @@ class TestRequestAuditor(object):
 
 class TestExceptionHandler(object):
     def test_handle_exception_masked(self, mocker):
-        handler = mocker.stub()
+        handler = mocker.Mock()
         eh = hooks.ExceptionHandler(handler)
         eh.handle_exception("consumer", "exc_type", "exc_val", "exc_tb")
         handler.assert_called_with("exc_type", "exc_val", "exc_tb")
@@ -45,8 +45,8 @@ class TestTransactionHookChain(object):
 
     def test_delegate_handle_response_multiple(self, mocker):
         # Include one hook that can't handle responses
-        mock_response_handler = mocker.stub()
-        mock_request_auditor = mocker.stub()
+        mock_response_handler = mocker.Mock()
+        mock_request_auditor = mocker.Mock()
 
         chain = hooks.TransactionHookChain(
             hooks.RequestAuditor(mock_request_auditor),

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -241,9 +241,13 @@ class ConsumerMeta(type):
             def new_init(self, *args, **kwargs):
                 init(self, *args, **kwargs)
                 call_args = utils.get_call_args(init, self, *args, **kwargs)
-                f = functools.partial(
-                    handler.handle_call_args, call_args=call_args
-                )
+
+                @functools.wraps(handler.handle_call_args)
+                def f(*args, **kwargs):
+                    return handler.handle_call_args(
+                        *args, **kwargs, call_args=call_args
+                    )
+
                 hook = hooks_.RequestAuditor(f)
                 self.session.inject(hook)
 

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -241,13 +241,9 @@ class ConsumerMeta(type):
             def new_init(self, *args, **kwargs):
                 init(self, *args, **kwargs)
                 call_args = utils.get_call_args(init, self, *args, **kwargs)
-
-                @functools.wraps(handler.handle_call_args)
-                def f(*args, **kwargs):
-                    return handler.handle_call_args(
-                        *args, **kwargs, call_args=call_args
-                    )
-
+                f = functools.partial(
+                    handler.handle_call_args, call_args=call_args
+                )
                 hook = hooks_.RequestAuditor(f)
                 self.session.inject(hook)
 

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -41,11 +41,7 @@ class RequestPreparer(object):
         return chain
 
     def _wrap_hook(self, func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            return func(self._consumer, *args, **kwargs)
-
-        return wrapper
+        return functools.partial(func, self._consumer)
 
     def apply_hooks(self, execution_builder, chain):
         # TODO:

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -7,6 +7,7 @@ from uplink import (
     arguments,
     auth as auth_,
     clients,
+    compat,
     converters as converters_,
     exceptions,
     helpers,
@@ -41,7 +42,11 @@ class RequestPreparer(object):
         return chain
 
     def _wrap_hook(self, func):
-        return functools.partial(func, self._consumer)
+        @compat.wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(self._consumer, *args, **kwargs)
+
+        return wrapper
 
     def apply_hooks(self, execution_builder, chain):
         # TODO:

--- a/uplink/builder.py
+++ b/uplink/builder.py
@@ -41,7 +41,11 @@ class RequestPreparer(object):
         return chain
 
     def _wrap_hook(self, func):
-        return functools.partial(func, self._consumer)
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(self._consumer, *args, **kwargs)
+
+        return wrapper
 
     def apply_hooks(self, execution_builder, chain):
         # TODO:

--- a/uplink/clients/aiohttp_.py
+++ b/uplink/clients/aiohttp_.py
@@ -5,6 +5,7 @@ that returns awaitable responses.
 # Standard library imports
 import asyncio
 import collections
+import inspect
 import threading
 from concurrent import futures
 
@@ -86,7 +87,8 @@ class AiohttpClient(interfaces.HttpClientAdapter):
         return self._session
 
     def wrap_callback(self, callback):
-        if not asyncio.iscoroutinefunction(callback):
+        func = inspect.unwrap(callback)
+        if not asyncio.iscoroutinefunction(func):
             callback = self._sync_callback_adapter(callback)
         return callback
 

--- a/uplink/compat.py
+++ b/uplink/compat.py
@@ -5,3 +5,4 @@ __all__ = ["abc", "reraise"]
 
 abc = six.moves.collections_abc
 reraise = six.reraise
+wraps = six.wraps

--- a/uplink/hooks.py
+++ b/uplink/hooks.py
@@ -2,9 +2,6 @@
 This module provides a class for defining custom handling for specific
 points of an HTTP transaction.
 """
-# Standard library imports
-import functools
-
 # Local imports
 from uplink import compat
 
@@ -18,7 +15,7 @@ def _wrap_if_necessary(hook, requires_consumer):
 
 
 def _wrap_to_ignore_consumer(hook):
-    @functools.wraps(hook)
+    @compat.wraps(hook)
     def wrapper(_, *args, **kwargs):
         # Expects that consumer is the first argument
         return hook(*args, **kwargs)

--- a/uplink/hooks.py
+++ b/uplink/hooks.py
@@ -2,6 +2,9 @@
 This module provides a class for defining custom handling for specific
 points of an HTTP transaction.
 """
+# Standard library imports
+import functools
+
 # Local imports
 from uplink import compat
 
@@ -15,6 +18,7 @@ def _wrap_if_necessary(hook, requires_consumer):
 
 
 def _wrap_to_ignore_consumer(hook):
+    @functools.wraps(hook)
     def wrapper(_, *args, **kwargs):
         # Expects that consumer is the first argument
         return hook(*args, **kwargs)


### PR DESCRIPTION
Async callbacks are being wrapped by ThreadedCoroutine when they shouldn't be. For some context, the purpose of ThreadedCoroutine is to allow sync callbacks with aiohttp client. When the callback is an async function, [this condition](https://github.com/prkumar/uplink/blob/master/uplink/clients/aiohttp_.py#L89) should skip this behavior.

Fixes #256