### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,9 @@ metadata = {
     "author": "P. Raj Kumar",
     "author_email": "raj.pritvi.kumar@gmail.com",
     "url": "https://uplink.readthedocs.io/",
+    "project_urls": {
+        "Source": "https://github.com/prkumar/uplink",
+    },
     "license": "MIT",
     "description": "A Declarative HTTP Client for Python.",
     "long_description": read("README.rst"),


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: https://pypi.org/pypi/requests/json
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)



Attention: @prkumar