### PR TITLE
Remove setuptools from cache before reinstalling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ after_success:
   - codecov
 before_deploy:
   - python verify_tag.py --tag $TRAVIS_TAG
+  - pip cache remove setuptools
   - pip install setuptools==60.8.2
 deploy:
   provider: pypi


### PR DESCRIPTION
Seems that travis is using cached wheel of newer version, which is causing the bug in 60.9 to remain although we've pinned to 60.8.2.