### PR TITLE
Pydantic v2 support

### DIFF
--- a/tests/unit/test_converters.py
+++ b/tests/unit/test_converters.py
@@ -6,7 +6,7 @@ import sys
 import marshmallow
 
 try:
-    import pydantic
+    import pydantic.v1 as pydantic
 except ImportError:
     if sys.version_info >= (3, 6):
         raise

--- a/uplink/converters/pydantic_.py
+++ b/uplink/converters/pydantic_.py
@@ -9,7 +9,7 @@ from uplink.utils import is_subclass
 
 
 def _encode_pydantic(obj):
-    from pydantic.json import pydantic_encoder
+    from pydantic.v1.json import pydantic_encoder
 
     # json atoms
     if isinstance(obj, (str, int, float, bool)) or obj is None:
@@ -74,7 +74,7 @@ class PydanticConverter(Factory):
     """
 
     try:
-        import pydantic
+        import pydantic.v1 as pydantic
     except ImportError:  # pragma: no cover
         pydantic = None
 

--- a/uplink/converters/pydantic_.py
+++ b/uplink/converters/pydantic_.py
@@ -9,7 +9,7 @@ from uplink.utils import is_subclass
 
 
 def _encode_pydantic(obj):
-    from pydantic.v1.json import pydantic_encoder
+    from pydantic_core import to_jsonable_python
 
     # json atoms
     if isinstance(obj, (str, int, float, bool)) or obj is None:
@@ -22,7 +22,7 @@ def _encode_pydantic(obj):
         return [_encode_pydantic(i) for i in obj]
 
     # pydantic types
-    return _encode_pydantic(pydantic_encoder(obj))
+    return _encode_pydantic(to_jsonable_python(obj))
 
 
 class _PydanticRequestBody(Converter):
@@ -74,7 +74,7 @@ class PydanticConverter(Factory):
     """
 
     try:
-        import pydantic.v1 as pydantic
+        import pydantic
     except ImportError:  # pragma: no cover
         pydantic = None
 


### PR DESCRIPTION
Fixes #297

Changes proposed in this pull request:
- Pydantic V2 is supported 
- existing async tests supports python > 3.8 now

Attention: @prkumar