### PR TITLE
Allow arguments initialization using subscription syntax

### DIFF
--- a/docs/source/user/tips.rst
+++ b/docs/source/user/tips.rst
@@ -137,6 +137,16 @@ When using Python 3, you can use these classes as function annotations
         def get_commit(self, commit_url: uplink.Url, sha: uplink.Path):
             pass
 
+Annotations receiving a :py:class:`str` or a :obj:`type` can be also initialized
+by using `generic types emulation <https://docs.python.org/3/reference/datamodel.html#emulating-generic-types>`_:
+
+.. code-block:: python
+   :emphasize-lines: 3
+
+    class GitHub(uplink.Consumer):
+        @uplink.get("user")
+        def get_user(self, authorization: Header["Authorization"]):
+            """Get an authenticated user."""
 
 .. _`annotating constructor arguments`:
 

--- a/tests/unit/test_arguments.py
+++ b/tests/unit/test_arguments.py
@@ -196,6 +196,8 @@ class TestTypedArgument:
     def test_type(self):
         assert arguments.TypedArgument("hello").type == "hello"
 
+        assert arguments.TypedArgument["hello"].type == "hello"
+
     def test_set_type(self):
         annotation = arguments.TypedArgument()
         assert annotation.type is None
@@ -211,6 +213,8 @@ class TestTypedArgument:
 class TestNamedArgument:
     def test_name(self):
         assert arguments.NamedArgument("name").name == "name"
+
+        assert arguments.NamedArgument["name"].name == "name"
 
     def test_set_name(self):
         annotation = arguments.NamedArgument()

--- a/uplink/arguments.py
+++ b/uplink/arguments.py
@@ -184,6 +184,10 @@ class TypedArgument(ArgumentAnnotation):
     def __init__(self, type=None):
         self._type = type
 
+    @classmethod
+    def __class_getitem__(cls, type):
+        return cls(type=type)
+
     @property
     def type(self):
         return self._type
@@ -206,6 +210,10 @@ class NamedArgument(TypedArgument):
     def __init__(self, name=None, type=None):
         self._arg_name = name
         super().__init__(type)
+
+    @classmethod
+    def __class_getitem__(cls, name):
+        return cls(name=name)
 
     @property
     def name(self):


### PR DESCRIPTION
Changes proposed in this pull request:
- Allow argument annotations with generics syntax:
  ```python
  class GitHub(uplink.Consumer):
      @uplink.get("user")
      def get_user(self, authorization: Header["Authorization"]):
          """Get an authenticated user."""
  ```